### PR TITLE
Makefile: remove GOARCH=amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ IMAGE_REGISTRY=quay.io
 vpath bin/go-bindata $(GOPATH)
 GOBINDATA_BIN=bin/go-bindata
 
-ENVVAR=GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+ENVVAR=GOOS=linux CGO_ENABLED=0
 GOOS=linux
 GO_BUILD_RECIPE=GOOS=$(GOOS) go build -o $(BIN) $(MAIN_PACKAGE)
 


### PR DESCRIPTION
This is the third Makefile I've seen like this, and as far as I've seen it hasn't hurt to remove the hardcoded GOARCH here. It *does* hurt to leave it in because builds on other architectures simply cross-compile an amd64 binary which is not what we want.

Can you let me know where this Makefile originated? I'd like to fix it at whatever source that may be.