### PR TITLE
Disable default project-wide node selector.

### DIFF
--- a/manifests/0100_namespace.yaml
+++ b/manifests/0100_namespace.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-nfd-operator
-
+  annotations:
+    openshift.io/node-selector: ''


### PR DESCRIPTION
Scheduling is incompatible with default node selector.