### PR TITLE
Allow additional NVIDIA namespace for labels

### DIFF
--- a/assets/master/0400_master_daemonset.yaml
+++ b/assets/master/0400_master_daemonset.yaml
@@ -30,7 +30,7 @@ spec:
                 fieldPath: spec.nodeName
           image: $(NODE_FEATURE_DISCOVERY_IMAGE)
           name: nfd-master
-          command: ["nfd-master", "--port=12000"]
+          command: ["nfd-master", "--port=12000", "--extra-label-ns=nvidia.com"]
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false


### PR DESCRIPTION
For side-car containers to publish labels with custom prefix, one needs to tell the nfd-master to publish those labels explicitly. 