### PR TITLE
[Bug 1744167] nfd.package.yaml: match OCP channel name

### DIFF
--- a/manifests/olm-catalog/nfd.package.yaml
+++ b/manifests/olm-catalog/nfd.package.yaml
@@ -1,4 +1,4 @@
 packageName: nfd
 channels:
-- name: stable
+- name: 4.2
   currentCSV: nfd.v4.2


### PR DESCRIPTION
For the future we want to use a channel name that matches the release it's for.

This is to enable the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1744167