### PR TITLE
Tolerate only worker nodes for custom taints

### DIFF
--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -14,7 +14,10 @@ spec:
       labels:
         app: nfd-worker
     spec:
+      nodeSelector:
+        node-role.kubernetes.io/worker: ""
       tolerations:
+      - operator: Exists
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule


### PR DESCRIPTION
NFD worker pods should run on any worker, regardless the toleration an admin/user may put on. 