### PR TITLE
Bug 1772575: The channel name is number, it should be string in nfd.package.yaml

### DIFF
--- a/manifests/olm-catalog/nfd.package.yaml
+++ b/manifests/olm-catalog/nfd.package.yaml
@@ -1,4 +1,4 @@
 packageName: nfd
 channels:
-- name: 4.2
+- name: '4.2'
   currentCSV: nfd.v4.2.0


### PR DESCRIPTION
The channel name is number, it should be string in nfd.package.yaml