### PR TITLE
Bug 1770084: The channel name should be string in nfd.package.yaml

### DIFF
--- a/manifests/olm-catalog/nfd.package.yaml
+++ b/manifests/olm-catalog/nfd.package.yaml
@@ -1,5 +1,5 @@
 packageName: nfd
 channels:
-- name: 4.3
+- name: '4.3'
   currentCSV: nfd.v4.3.0
   


### PR DESCRIPTION
The channel name should be string in nfd.package.yaml