### PR TITLE
Bug 1780678: Added `type: object` to description, worked in 4.2 now needed

### DIFF
--- a/manifests/0500_crd.yaml
+++ b/manifests/0500_crd.yaml
@@ -1,15 +1,1 @@
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: nodefeaturediscoveries.nfd.openshift.io
-spec:
-  group: nfd.openshift.io
-  names:
-    kind: NodeFeatureDiscovery
-    listKind: NodeFeatureDiscoveryList
-    plural: nodefeaturediscoveries
-    singular: nodefeaturediscovery
-  scope: Namespaced
-  version: v1alpha1
-  subresources:
-    status: {}
+olm-catalog/4.4/nfd.crd.yaml

--- a/manifests/olm-catalog/4.4/nfd.crd.yaml
+++ b/manifests/olm-catalog/4.4/nfd.crd.yaml
@@ -17,6 +17,7 @@ spec:
   validation:
     openAPIV3Schema:
       description: 'The Cluster Node Feature Discovery operator manages detection of hardware features and configuration in a Openshift cluster. The operator orchestrates all resources needed to run the NFD DaemonSet (Upstream: https://github.com/kubernetes-sigs/node-feature-discovery)'
+      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
Added `type: object` to description, worked in 4.2 without now needed in 4.3+