### PR TITLE
Replace image registry

### DIFF
--- a/assets/node-feature-discovery/05-nfd-daemonset.yml
+++ b/assets/node-feature-discovery/05-nfd-daemonset.yml
@@ -22,7 +22,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: quay.io/openshift-psap/node-feature-discovery:v0.5.0
+          image: quay.io/openshift-psap/node-feature-discovery:v0.4.0
           name: node-feature-discovery
           command: ["/usr/bin/node-feature-discovery"]
           args:

--- a/assets/node-feature-discovery/05-nfd-daemonset.yml
+++ b/assets/node-feature-discovery/05-nfd-daemonset.yml
@@ -22,7 +22,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          image: quay.io/zvonkok/node-feature-discovery:v4.0
+          image: quay.io/openshift-psap/node-feature-discovery:v0.5.0
           name: node-feature-discovery
           command: ["/usr/bin/node-feature-discovery"]
           args:

--- a/manifests/0600_operator.yaml
+++ b/manifests/0600_operator.yaml
@@ -44,7 +44,7 @@ spec:
             - name: OPERATOR_NAME
               value: "cluster-nfd-operator"
             - name: NODE_FEATURE_DISCOVERY_IMAGE
-              value: "quay.io/zvonkok/node-feature-discovery:v4.2"
+              value: "quay.io/openshift-psap/node-feature-discovery:v0.5.0"
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/manifests/0700_cr.yaml
+++ b/manifests/0700_cr.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: REPLACE_NAMESPACE
 spec:
   namespace: openshift-nfd
-  image: quay.io/zvonkok/node-feature-discovery:v4.2
+  image: quay.io/openshift-psap/node-feature-discovery:v0.5.0

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -58,7 +58,7 @@ var (
 	cleanupTimeout       = time.Second * 30
 	opName               = "nfd-master-client"
 	opNamespace          = "openshift-nfd"
-	opImage              = "quay.io/zvonkok/node-feature-discovery:v4.2"
+	opImage              = "quay.io/openshift-psap/node-feature-discovery:v0.5.0"
 	//opImage = "registry.svc.ci.openshift.org/openshift/node-feature-discovery-container:v4.2"
 )
 


### PR DESCRIPTION
Replace image registry
> zvonkok -> openshift-psap

new images can be found at:
 - [quay.io/openshift-psap/node-feature-discovery](https://quay.io/repository/openshift-psap/node-feature-discovery)
 - [quay.io/openshift-psap/cluster-nfd-operator](https://quay.io/repository/openshift-psap/cluster-nfd-operator)

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>