### PR TITLE
[release-4.3] Bug 1805175: add GO111MODULE=on

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ GOBINDATA_BIN=bin/go-bindata
 
 ENVVAR=GOOS=linux CGO_ENABLED=0
 GOOS=linux
-GO_BUILD_RECIPE=GOOS=$(GOOS) go build -mod=vendor -o $(BIN) $(MAIN_PACKAGE)
+GO111MODULE=on
+GO_BUILD_RECIPE=GO111MODULE=$(GO111MODULE) GOOS=$(GOOS) go build -mod=vendor -o $(BIN) $(MAIN_PACKAGE)
 
 all: build
 


### PR DESCRIPTION
Add GO111MODULE=on to `GO_BUILD_RECIPE` on Makefile target `make build`

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>