### PR TITLE
Set the correct namespace for SCC when installed in non default namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,9 @@ undeploy:
 	for obj in $(DEPLOY_OBJECTS) $(DEPLOY_CRDS) $(DEPLOY_CRS); do \
 		$(TEMPLATE_CMD) $$obj | kubectl delete -f - ;\
 	done	
-	 ## Delete everything for the operator from the cluster
-#	-${TEMPLATE_CMD} $(DEPLOY_OBJECTS) $(DEPLOY_OPERATOR) $(DEPLOY_CRDS) $(DEPLOY_CRS) | kubectl delete -f -
+
+	kubectl delete scc nfd-worker
+
 
 verify:	verify-gofmt
 

--- a/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
+++ b/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
@@ -366,6 +366,9 @@ func SecurityContextConstraints(n NFD) (ResourceStatus, error) {
 	state := n.idx
 	obj := n.resources[state].SecurityContextConstraints
 
+	// Set the correct namespace for SCC when installed in non default namespace
+	obj.Users[0] = "system:serviceaccount:" + n.ins.GetName() + ":" + obj.GetName()
+
 	found := &secv1.SecurityContextConstraints{}
 	logger := log.WithValues("SecurityContextConstraints", obj.Name, "Namespace", "default")
 

--- a/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
+++ b/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_controls.go
@@ -367,7 +367,7 @@ func SecurityContextConstraints(n NFD) (ResourceStatus, error) {
 	obj := n.resources[state].SecurityContextConstraints
 
 	// Set the correct namespace for SCC when installed in non default namespace
-	obj.Users[0] = "system:serviceaccount:" + n.ins.GetName() + ":" + obj.GetName()
+	obj.Users[0] = "system:serviceaccount:" + n.ins.GetNamespace() + ":" + obj.GetName()
 
 	found := &secv1.SecurityContextConstraints{}
 	logger := log.WithValues("SecurityContextConstraints", obj.Name, "Namespace", "default")


### PR DESCRIPTION
The SCC has a users field where one can specify the ServiceAccount from a specific Namespace to be used. When installing NFD in a non-default namespace, the SCC ServiceAccount namespace has to be updated.