### PR TITLE
fix softlink pointing to 4.4 olm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REGISTRY       ?= quay.io
-ORG            ?= zvonkok
+ORG            ?= openshift-psap
 TAG            ?= $(shell git branch | grep \* | cut -d ' ' -f2)
 IMAGE          ?= $(REGISTRY)/$(ORG)/cluster-nfd-operator:$(TAG)
 NAMESPACE      ?= openshift-nfd
@@ -19,7 +19,7 @@ BINDATA=pkg/manifests/bindata.go
 GOFMT_CHECK=$(shell find . -not \( \( -wholename './.*' -o -wholename '*/vendor/*' \) -prune \) -name '*.go' | sort -u | xargs gofmt -s -l)
 
 DOCKERFILE=Dockerfile
-IMAGE_TAG=openshift/origin-cluster-nfd-operator
+IMAGE_TAG=openshift-psap/origin-cluster-nfd-operator
 IMAGE_REGISTRY=quay.io
 
 vpath bin/go-bindata $(GOPATH)

--- a/manifests/0500_crd.yaml
+++ b/manifests/0500_crd.yaml
@@ -1,1 +1,1 @@
-olm-catalog/4.4/nfd.crd.yaml
+olm-catalog/4.5/nfd.crd.yaml

--- a/manifests/olm-catalog/4.5/nfd.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/olm-catalog/4.5/nfd.v4.5.0.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
         }
       ]
     description: This software enables node feature discovery for Kubernetes. It detects hardware features available on each node in a Kubernetes cluster, and advertises those features using node labels.
-    olm.skipRange: ">=4.1.0 <4.5.0"
+    olm.skipRange: ">=4.1.0 <4.6.0"
 spec:
   displayName: Node Feature Discovery    
   version: 4.5.0


### PR DESCRIPTION
Also now that images are being held on openshift-psap quay, we can change the ORG env var on the Makefile

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>