### PR TITLE
Bug 1850546: Add support label for s390x & ppc64le

### DIFF
--- a/manifests/olm-catalog/4.6/nfd.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/olm-catalog/4.6/nfd.v4.6.0.clusterserviceversion.yaml
@@ -3,6 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   name: nfd.v4.6.0
   namespace: placeholder
+  labels:
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
   annotations:
     capabilities: Basic Install
     categories: "Database"


### PR DESCRIPTION
In order for the nfd-operator to be correctly filtered in the
OperatorHub for s390x and ppc64le we need to add the correct arch
label as supported.