### PR TITLE
[release-4.5] Bug 1855312: Add support label for s390x & ppc64le

### DIFF
--- a/manifests/olm-catalog/4.5/nfd.v4.5.0.clusterserviceversion.yaml
+++ b/manifests/olm-catalog/4.5/nfd.v4.5.0.clusterserviceversion.yaml
@@ -3,6 +3,10 @@ kind: ClusterServiceVersion
 metadata:
   name: nfd.v4.5.0
   namespace: placeholder
+  labels:
+    "operatorframework.io/arch.amd64": supported
+    "operatorframework.io/arch.ppc64le": supported
+    "operatorframework.io/arch.s390x": supported
   annotations:
     capabilities: Basic Install
     categories: "Database"


### PR DESCRIPTION
In order for the nfd-operator to be correctly filtered in the
OperatorHub for s390x and ppc64le we need to add the correct arch
label as supported.

(cherry picked from commit 3d67f5dfca154ba7ce7c4b6a39b6adc7f10e5f5c)