### PR TITLE
Bug 1813503: [release-4.5]  Dockerfile not compatible with docker and…

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,7 +7,7 @@ FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-nfd-operator/cluster-nfd-operator /usr/bin/
 
 RUN mkdir -p /opt/nfd
-COPY assets/* /opt/nfd/.
+COPY assets /opt/nfd
 
 COPY manifests/olm-catalog/$CSV /manifests/$CSV
 COPY manifests/olm-catalog/nfd.package.yaml /manifests/


### PR DESCRIPTION
… buildah

Re write the COPY step at Dockerfile.rhel7

> COPY with glob does not preserve subdirectory structure

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>