### PR TITLE
Bug 1868616: Enhance nfd-worker placement

### DIFF
--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -13,13 +13,16 @@ spec:
       labels:
         app: nfd-worker
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""
       tolerations:
-      - operator: Exists
-      - key: nvidia.com/gpu
-        operator: Exists
-        effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoSchedule"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key:  node-role.kubernetes.io/master
+                operator: DoesNotExist
       hostNetwork: true
       serviceAccount: nfd-worker
       readOnlyRootFilesystem: true
@@ -78,5 +81,3 @@ spec:
             items:
               - key: nfd-worker-conf
                 path: nfd-worker.conf
-
-


### PR DESCRIPTION
* Enhance nfd-worker placement

Enable NFD operator to deploy nfd-worker pods on nodes labeled other
than "node-role.kubernetes.io/worker"

*Also: Add clean-labels make target
*Also: some housekeeping to the Makefile

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>