### PR TITLE
fix sync

### DIFF
--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -24,7 +24,7 @@ spec:
                   - key: node-role.kubernetes.io/master
                     operator: DoesNotExist
               - matchExpressions:
-                  - key: node-role.kubernetes.io/node
+                  - key: node-role.kubernetes.io/worker
                     operator: Exists
       hostNetwork: true
       serviceAccount: nfd-worker


### PR DESCRIPTION
After the back-port from upstream, this PR is needed to satisfy OpenShift way of naming nodes "worker" 
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>