### PR TITLE
added Recreate strategy instead of the default

### DIFF
--- a/manifests/0600_operator.yaml
+++ b/manifests/0600_operator.yaml
@@ -8,6 +8,8 @@ spec:
   selector:
     matchLabels:
       name: nfd-operator
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Description of changes:
- By default, the operator deployment is created with RollingUpdate strategy. To avoid hitting Issue #107 this PR declares the `.spec.strategy.type Recreate` field.