### PR TITLE
[release-4.6] Bug 1916007: olm skip range is set to the wrong range

### DIFF
--- a/manifests/olm-catalog/4.6/nfd.v4.6.0.clusterserviceversion.yaml
+++ b/manifests/olm-catalog/4.6/nfd.v4.6.0.clusterserviceversion.yaml
@@ -31,7 +31,7 @@ metadata:
         }
       ]
     description: This software enables node feature discovery for Kubernetes. It detects hardware features available on each node in a Kubernetes cluster, and advertises those features using node labels.
-    olm.skipRange: ">=4.1.0 <4.7.0"
+    olm.skipRange: ">=4.3.0 <4.6.0"
 spec:
   displayName: Node Feature Discovery    
   version: 4.6.0


### PR DESCRIPTION
my understanding is this wouldn't upgrade to 4.1.0-> to 4.7.0,
meaning it would miss upgrade in 4.6.z

We saw same issue https://github.com/openshift/cluster-nfd-operator/pull/124/files
and the issue comes from mis-understanding of olm.skipRange.