### PR TITLE
Bug 1823765: Enable service DNS for nfd-master

### DIFF
--- a/assets/master/0500_service.yaml
+++ b/assets/master/0500_service.yaml
@@ -11,4 +11,3 @@ spec:
     port: 12000
     targetPort: 12000
     name: nfd
-

--- a/assets/worker/0700_worker_daemonset.yaml
+++ b/assets/worker/0700_worker_daemonset.yaml
@@ -13,6 +13,7 @@ spec:
       labels:
         app: nfd-worker
     spec:
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         - operator: "Exists"
           effect: "NoSchedule"
@@ -41,7 +42,7 @@ spec:
             - "nfd-worker"
           args:
             - "--sleep-interval=60s"
-            - "--server=$(NFD_MASTER_SERVICE_HOST):$(NFD_MASTER_SERVICE_PORT)"
+            - "--server=nfd-master:12000"
           volumeMounts:
             - name: host-boot
               mountPath: "/host-boot"


### PR DESCRIPTION
This Patch enables service DNS for the `nfd-master` allowing `nfd-workers` to discover the NFD server without passing an IP  but the service name
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>