### PR TITLE
Bug 1923998: Remove readines probe from old operator sdk

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -12,7 +12,6 @@ import (
 	nodefeaturediscovery "github.com/openshift/cluster-nfd-operator/pkg/controller/nodefeaturediscovery"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
-	"github.com/operator-framework/operator-sdk/pkg/ready"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -59,19 +58,6 @@ func main() {
 		log.Error(err, "")
 		os.Exit(1)
 	}
-
-	r := ready.NewFileReady()
-	err = r.Set()
-	if err != nil {
-		log.Error(err, "")
-		os.Exit(1)
-	}
-	defer func() {
-		if err = r.Unset(); err != nil {
-			log.Error(err, "")
-			os.Exit(1)
-		}
-	}()
 
 	// Create a new Cmd to provide shared dependencies and start components
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace})

--- a/manifests/0600_operator.yaml
+++ b/manifests/0600_operator.yaml
@@ -24,14 +24,6 @@ spec:
           command:
           - cluster-nfd-operator
           imagePullPolicy: IfNotPresent
-          readinessProbe:
-            exec:
-              command:
-                - stat
-                - /tmp/operator-sdk-ready
-            initialDelaySeconds: 4
-            periodSeconds: 10
-            failureThreshold: 1
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -50,12 +42,6 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: ["ALL"]
-          volumeMounts:
-          - mountPath: /tmp
-            name: tmp
-      volumes:
-      - name: tmp
-        emptyDir: {}
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:


### PR DESCRIPTION
operator sdk was creating a readines file, requiring a VolumeMount from
the host, that is causing seameless uipdtas/upgrades to fail.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>