### PR TITLE
Bug 1923998: Remove readines probe from CSV

### DIFF
--- a/manifests/olm-catalog/4.7/nfd.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/olm-catalog/4.7/nfd.v4.7.0.clusterserviceversion.yaml
@@ -26,7 +26,7 @@ metadata:
             },
             "spec": {
                 "operand": {
-                    "image": "quay.io/openshift/origin-node-feature-discovery:4.7",
+                    "image": "registry.redhat.io/openshift4/ose-node-feature-discovery:v4.7.0",
                     "imagePullPolicy": "Always",
                     "namespace": "node-feature-discovery-operator"
                 },
@@ -70,71 +70,40 @@ spec:
     spec:
       clusterPermissions:
       - rules:
-        - apiGroups:
-          - rbac.authorization.k8s.io
-          resources:
-          - roles
-          - rolebindings
-          - clusterroles
-          - clusterrolebindings
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - pods
-          - services
-          - endpoints
-          - persistentvolumeclaims
-          - events
-          - configmaps
-          - secrets
-          - serviceaccounts
-          - nodes
-          verbs:
-          - '*'
-        - apiGroups:
-          - ""
-          resources:
-          - namespaces
-          verbs:
-          - '*'
-        - apiGroups:
-          - apps
-          resources:
-          - deployments
-          - daemonsets
-          - replicasets
-          - statefulsets
-          verbs:
-          - '*'
-        - apiGroups:
-          - monitoring.coreos.com
-          resources:
-          - servicemonitors
-          verbs:
-          - get
-          - create
-        - apiGroups:
-          - nfd.openshift.io
-          resources:
-          - '*'
-          verbs:
-          - '*'
-        - apiGroups:
-          - policy
-          resourceNames:
-          - nfd-worker
-          resources:
-          - podsecuritypolicies
-          verbs:
-          - use
-        - apiGroups:
-          - security.openshift.io
-          resources:
-          - securitycontextconstraints
-          verbs:
-          - '*'
+        - apiGroups: ["rbac.authorization.k8s.io"]
+          resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
+          verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups: [""]
+          resources: ["pods", "services", "endpoints", "persistentvolumeclaims", "events", "configmaps", "secrets", "serviceaccounts",  "nodes"]
+          verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups: [""]
+          resources: ["namespaces"]
+          verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups: ["apps"]
+          resources: ["deployments", "daemonsets", "replicasets", "statefulsets"]
+          verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups: ["monitoring.coreos.com"]
+          resources: ["servicemonitors"]
+          verbs: ["get", "create"]
+        - apiGroups: ["nfd.openshift.io"]
+          resources: ["deployments", "daemonsets", "replicasets", "statefulsets"]
+          verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups: ["policy"]
+          resourceNames: ["nfd-worker"]
+          resources: ["podsecuritypolicies"]
+          verbs: ["use"]
+        - apiGroups: ["security.openshift.io"]
+          resources: ["securitycontextconstraints"]
+          verbs: ["use","create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups: ["nfd.openshift.io", "nfd.openshift.io/finalizers"]
+          resources: ["nodefeaturediscoveries"]
+          verbs: ["use","create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups: ["nfd.openshift.io", "nfd.openshift.io/finalizers"]
+          resources: ["nodefeaturediscoveries","nodefeaturediscoveries/finalizers"]
+          verbs: ["use","create", "delete", "get", "list", "patch", "update", "watch"]
+        - apiGroups:  ["nfd.openshift.io", "nfd.openshift.io/finalizers"]
+          resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings", "pods", "services", "endpoints", "persistentvolumeclaims", "events", "configmaps", "secrets", "serviceaccounts", "serviceaccounts/finalizers", "nodes"]
+          verbs: ["use","create", "delete", "get", "list", "patch", "update", "watch"]
         serviceAccountName: nfd-operator
       deployments:
       - name: nfd-operator
@@ -164,18 +133,13 @@ spec:
                 - name: OPERATOR_NAME
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
-                  value: quay.io/openshift/origin-node-feature-discovery:latest
-                image: quay.io/openshift/origin-cluster-nfd-operator:latest
+                  value: quay.io/openshift/origin-node-feature-discovery:4.7
+                image: quay.io/openshift/origin-cluster-nfd-operator:4.7
                 imagePullPolicy: Always
                 name: nfd-operator
                 ports:
                 - containerPort: 60000
                   name: metrics
-                readinessProbe:
-                  exec:
-                    command:
-                    - stat
-                    - /tmp/operator-sdk-ready
                   failureThreshold: 1
                   initialDelaySeconds: 4
                   periodSeconds: 10
@@ -186,9 +150,6 @@ spec:
                     drop:
                     - ALL
                   readOnlyRootFilesystem: true
-                volumeMounts:
-                - mountPath: /tmp
-                  name: tmp
               nodeSelector:
                 node-role.kubernetes.io/master: ""
               serviceAccountName: nfd-operator
@@ -196,9 +157,6 @@ spec:
               - effect: NoSchedule
                 key: node-role.kubernetes.io/master
                 operator: Equal
-              volumes:
-              - emptyDir: {}
-                name: tmp
     strategy: deployment
   installModes:
   - supported: true


### PR DESCRIPTION
PR https://github.com/openshift/cluster-nfd-operator/pull/132 removed
the readiness probe from manual manifest deployment, this PR modifies
the CSV that handles the behaviour of the operator when deployed from
operatorhub

This PR also address Bug 1914869

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>