### PR TITLE
nodefeaturediscovery_state: avoid accumulating states

### DIFF
--- a/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_state.go
+++ b/pkg/controller/nodefeaturediscovery/nodefeaturediscovery_state.go
@@ -39,8 +39,10 @@ func (n *NFD) init(
 	n.ins = i
 	n.idx = 0
 
-	addState(n, "/opt/nfd/master")
-	addState(n, "/opt/nfd/worker")
+	if len(n.controls) == 0 {
+		addState(n, "/opt/nfd/master")
+		addState(n, "/opt/nfd/worker")
+	}
 
 	return
 }


### PR DESCRIPTION
the method init is called everytime the reconcile loop is called,
accumulating states, leading to a cascade of logs.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>