### PR TITLE
[release-4.7] Bug 1944242: Update nfd.v4.7.0.clusterserviceversion.yaml

### DIFF
--- a/manifests/olm-catalog/4.7/nfd.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/olm-catalog/4.7/nfd.v4.7.0.clusterserviceversion.yaml
@@ -12,7 +12,7 @@ metadata:
     categories: "Database"
     provider: Red Hat
     support: Red Hat
-    containerImage: 
+    containerImage: registry.redhat.io/openshift4/ose-cluster-nfd-operator:v4.7.0
     createdAt: 2019-05-30T00:00:00Z
     certified: "false"
     repository: https://github.com/openshift/cluster-nfd-operator


### PR DESCRIPTION
Bundle build for cluster-nfd-operator is failing on OSBS. It seems to me that OSBS introduced a check and disallows null values in annotations.
cluster-nfd-operator/manifests/olm-catalog/4.7/nfd.v4.7.0.clusterserviceversion.yaml
```
Line 15 in 110fdc7
 containerImage:  
```

is empty. We need to either give it a value to use an empty string "", though I am not sure if the check will allow empty strings or not.