### PR TITLE
Bug 1949102: Fix image build on disconnected envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ go_mod:
 	@go mod download
 
 # Build binary
-build: go_mod
+build:
 	@GOOS=$(GOOS) GO111MODULE=on CGO_ENABLED=0 go build -o $(BIN) $(MAIN_PACKAGE)
 
 # Run against the configured Kubernetes cluster in ~/.kube/config


### PR DESCRIPTION
This patch targets BZ 1949102:

NFD-operator fails to build on disconnected environments due to a `go get` command being call by the Makefile on the "build" target



Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>