### PR TITLE
Bug 1952145: cluster-nfd-operator executable file not found in $PATH error 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ endif
 
 GOOS=linux
 
-PACKAGE=github.com/openshift/cluster-nfd-opoerator
+PACKAGE=github.com/openshift/cluster-nfd-operator
 MAIN_PACKAGE=main.go
 BIN=node-feature-discovery-operator
 

--- a/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -73,8 +73,6 @@ spec:
                 - configData
                 type: object
             required:
-            - customConfig
-            - instance
             - operand
             - workerConfig
             type: object

--- a/manifests/0600_operator.yaml
+++ b/manifests/0600_operator.yaml
@@ -24,7 +24,7 @@ spec:
           - containerPort: 60000
             name: metrics
           command:
-          - cluster-nfd-operator
+          - node-feature-discovery-operator
           imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
@@ -38,7 +38,7 @@ spec:
             - name: OPERATOR_NAME
               value: "cluster-nfd-operator"
             - name: NODE_FEATURE_DISCOVERY_IMAGE
-              value: "quay.io/openshift/origin-node-feature-discovery:4.7"
+              value: "quay.io/openshift/origin-node-feature-discovery:4.8"
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/manifests/olm-catalog/4.8/nfd.v4.8.0.clusterserviceversion.yaml
+++ b/manifests/olm-catalog/4.8/nfd.v4.8.0.clusterserviceversion.yaml
@@ -120,7 +120,7 @@ spec:
             spec:
               containers:
               - command:
-                - cluster-nfd-operator
+                - node-feature-discovery-operator
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:


### PR DESCRIPTION
This patch attempts to fix CSV wrong command string
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>