### PR TITLE
Bug 1957846: Mount /usr inside the Pod

### DIFF
--- a/build/assets/node-feature-discovery/05-nfd-daemonset.yml
+++ b/build/assets/node-feature-discovery/05-nfd-daemonset.yml
@@ -32,6 +32,10 @@ spec:
               mountPath: "/host-boot"
             - name: host-sys
               mountPath: "/host-sys"
+            - name: host-usr-lib
+              mountPath: "/host-usr/lib"
+            - name: host-usr-src
+              mountPath: "/host-usr/src"
             - name: host-os-release
               mountPath: "/host-etc/os-release"
             - name: nfd-hooks
@@ -51,3 +55,9 @@ spec:
         - name: host-boot
           hostPath:
             path: "/boot"
+        - name: host-usr-lib
+          hostPath:
+            path: "/usr/lib"
+        - name: host-usr-src
+          hostPath:
+            path: "/usr/src"

--- a/build/assets/worker/05_worker_ds.yaml
+++ b/build/assets/worker/05_worker_ds.yaml
@@ -51,6 +51,12 @@ spec:
               readOnly: true
             - name: host-sys
               mountPath: "/host-sys"
+            - name: host-usr-lib
+              mountPath: "/host-usr/lib"
+              readOnly: true
+            - name: host-usr-src
+              mountPath: "/host-usr/src"
+              readOnly: true
             - name: nfd-worker-config
               mountPath: "/etc/kubernetes/node-feature-discovery"
             - name: nfd-hooks
@@ -75,6 +81,12 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
+        - name: host-usr-lib
+          hostPath:
+            path: "/usr/lib"
+        - name: host-usr-src
+          hostPath:
+            path: "/usr/src"
         - name: nfd-hooks
           hostPath:
             path: "/etc/kubernetes/node-feature-discovery/source.d"


### PR DESCRIPTION
Mount /usr as /host-usr inside the pod to allow NFD to find the kernel
configuration file inside /usr.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>

Addition to https://github.com/openshift/node-feature-discovery/pull/42