### PR TITLE
Adding documentation for the leader election flag in 'main.go'

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 
         // enableLeaderElection should be set to 'disable' by default If we enable leader
         // election, then only one node can run the controller manager and we will not
-        // have NFD running on all nodes.
+        // have NFD Operator running on all nodes.
 	var enableLeaderElection bool
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")

--- a/main.go
+++ b/main.go
@@ -65,6 +65,10 @@ func getWatchNamespace() (string, error) {
 
 func main() {
 	var metricsAddr string
+
+        // enableLeaderElection should be set to 'disable' by default If we enable leader
+        // election, then only one node can run the controller manager and we will not
+        // have NFD running on all nodes.
 	var enableLeaderElection bool
 	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
The documentation for the 'enable leader election' flag is nonexistent. This commit serves the purpose of adding documentation for this flag so that users and contributors both understand how it works, and it also serves the purpose of describing what the default flag value means.