### PR TITLE
Updating documentation in 'main.go' for 'metricsAddr'

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,12 @@ func getWatchNamespace() (string, error) {
 }
 
 func main() {
+	// metricsAddr is used by Prometheus to gather NFD's resource usage data. The bind
+	// address tells Prometheus which port to scrape this data's metrics from. The 
+	// metrics port defined by this flag must match the metrics port defined in the
+	// various manifests under ./manifests/[MAJOR].[MINOR]/manifests, where [MAJOR]
+	// corresponds to the OCP major version, and [MINOR] corresponds to the OCP minor
+	// version.
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string


### PR DESCRIPTION
Prometheus is used to scrape data (metrics) in relation to NFD resource usage. It is important for contributors to know and understand what 'metrics bind address' is and how it relates to this data scraping. It is also important for contributors to see how the metrics scraping bind address relates to the manifests under './manifests' and './config'.