### PR TITLE
Adding documentation for NFD related structs (types)

### DIFF
--- a/controllers/nodefeaturediscovery_resources.go
+++ b/controllers/nodefeaturediscovery_resources.go
@@ -33,7 +33,9 @@ import (
 
 type assetsFromFile []byte
 
-// Resources holds objects owned by NFD
+// Resources holds objects owned by NFD. This struct is used with the
+// 'NFD' struct to assist in the process of checking if NFD's resources
+// are 'Ready' or 'NotReady'.
 type Resources struct {
 	Namespace                  corev1.Namespace
 	ServiceAccount             corev1.ServiceAccount

--- a/controllers/nodefeaturediscovery_state.go
+++ b/controllers/nodefeaturediscovery_state.go
@@ -21,12 +21,26 @@ import (
 	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 )
 
-// NFD holds the needed information to watch from the Controller
+// NFD holds the needed information to watch from the Controller. The
+// following descriptions elaborate on each field in this struct:
 type NFD struct {
+	// resources contains information about NFD's resources. For more
+	// information, see ./nodefeaturediscovery_resources.go
 	resources []Resources
+
+	// controls is a list that contains the status of an NFD resource
+	// as being Ready (=0) or NotReady (=1)
 	controls  []controlFunc
+
+	// rec represents the NFD reconciler struct used for reconciliation
 	rec       *NodeFeatureDiscoveryReconciler
+
+	// ins is the NodeFeatureDiscovery struct that contains the Schema
+	// for the nodefeaturediscoveries API
 	ins       *nfdv1.NodeFeatureDiscovery
+
+	// idx is the index that is used to step through the 'controls' list
+	// and is set to 0 upon calling 'init()'
 	idx       int
 }
 


### PR DESCRIPTION
Adding documentation for structs defined in the two files in this commit. This documentation describes the fields within these structs so that contributors know what each field means and what each field does. These structs are used quite a bit in other .go files, and so it is important for contributors to be able to understand these structs.