### PR TITLE
Bug 1961484: enable art replacement for kube-rbac-proxy image

### DIFF
--- a/manifests/4.8/manifests/image-references
+++ b/manifests/4.8/manifests/image-references
@@ -10,3 +10,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-nfd-operator:4.8
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0


### PR DESCRIPTION
This patch adds kube-rbac-proxy image to ART image-references
Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>