### PR TITLE
Add support label for arm64

### DIFF
--- a/manifests/4.9/manifests/nfd.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/manifests/nfd.v4.9.0.clusterserviceversion.yaml
@@ -39,6 +39,7 @@ metadata:
     support: Red Hat
   labels:
     operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: node-feature-discovery-operator.v4.9.0


### PR DESCRIPTION
This is necessary for the operator to be displayed in the OperatorHub.
