### PR TITLE
Update the CSV to include the disconnected annotation

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,4 +1,19 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# These resources constitute the fully configured set of manifests
+# used to generate the 'manifests/' directory in a bundle.
 resources:
+- bases/node-feature-discovery-operator.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard
+
+patches:
+- target:
+    kind: ClusterServiceVersion
+  patch: |-
+    - op: add
+      path: /metadata/annotations
+      value:
+        operators.openshift.io/infrastructure-features: '["disconnected"]'

--- a/manifests/4.9/manifests/nfd.v4.9.0.clusterserviceversion.yaml
+++ b/manifests/4.9/manifests/nfd.v4.9.0.clusterserviceversion.yaml
@@ -32,6 +32,7 @@ metadata:
     containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.9
     description: This software enables node feature discovery for OpenShift. It detects hardware features available on each node in an OpenShift cluster, and advertises those features using node labels.
     olm.skipRange: '>=4.6.0 <4.9.0'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.4.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     provider: Red Hat


### PR DESCRIPTION
The NFD Operator claims it supports disconnected environments as listed here: [https://access.redhat.com/articles/4740011]. However, the operator CSV does not include the required annotation.

This patch – updates the CSV to include the disconnected annotation as listed here:
```yaml
metadata:
  annotations:
    operators.openshift.io/infrastructure-features: '["disconnected"]'
```

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>