### PR TITLE
Bug 1985465: Fix error messages that occur after degraded and progressing resources

### DIFF
--- a/controllers/nodefeaturediscovery_controller.go
+++ b/controllers/nodefeaturediscovery_controller.go
@@ -267,7 +267,7 @@ func (r *NodeFeatureDiscoveryReconciler) Reconcile(ctx context.Context, req ctrl
 		return r.updateDegradedCondition(instance, err.Error(), err)
 
 	} else if err != nil {
-		return r.updateDegradedCondition(instance, conditionFailedGettingNFDWorkerDaemonSet, err)
+		return r.updateDegradedCondition(instance, conditionFailedGettingNFDMasterDaemonSet, err)
 	}
 
 	// Get available conditions
@@ -277,29 +277,29 @@ func (r *NodeFeatureDiscoveryReconciler) Reconcile(ctx context.Context, req ctrl
 	r.updateStatus(instance, conditions)
 
 	if err := r.updateStatus(instance, conditions); err != nil {
-		if &result != nil {
-			return result, nil
+		if result != nil {
+			return *result, nil
 		}
 		return reconcile.Result{}, err
 	}
 
-	if &result != nil {
-		return result, nil
+	if result != nil {
+		return *result, nil
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func applyComponents() (reconcile.Result, error) {
+func applyComponents() (*reconcile.Result, error) {
 
 	for {
 		err := nfd.step()
 		if err != nil {
-			return reconcile.Result{}, err
+			return &reconcile.Result{}, err
 		}
 		if nfd.last() {
 			break
 		}
 	}
-	return ctrl.Result{}, nil
+	return &ctrl.Result{}, nil
 }

--- a/controllers/nodefeaturediscovery_status.go
+++ b/controllers/nodefeaturediscovery_status.go
@@ -124,7 +124,6 @@ func (r *NodeFeatureDiscoveryReconciler) updateStatus(nfd *nfdv1.NodeFeatureDisc
 	if !modified {
 		return nil
 	}
-
 	return r.Status().Update(context.TODO(), nfdCopy)
 }
 
@@ -142,7 +141,7 @@ func (r *NodeFeatureDiscoveryReconciler) updateDegradedCondition(nfd *nfdv1.Node
 	if err := r.updateStatus(nfd, conditions); err != nil {
 		return reconcile.Result{}, err
 	}
-	return reconcile.Result{}, conditionErr
+	return reconcile.Result{Requeue: true}, nil
 }
 
 // updateProgressingCondition is used to mark a given resource as "progressing" so
@@ -159,7 +158,7 @@ func (r *NodeFeatureDiscoveryReconciler) updateProgressingCondition(nfd *nfdv1.N
 	if err := r.updateStatus(nfd, conditions); err != nil {
 		return reconcile.Result{}, err
 	}
-	return reconcile.Result{}, conditionErr
+	return reconcile.Result{Requeue: true}, nil
 }
 
 // updateAvailableCondition is used to mark a given resource as "progressing" so


### PR DESCRIPTION
Add "Requeue: true" to the reconcile return values to force the
reconciler to rerun after a resource is degraded or progressing.
This is preferred over throwing an error message in the return
value of the Reconcile function.

Additionally, fix the status message for the master daemonset, as
it was referring to the worker daemonset and not the master
daemonset.