### PR TITLE
Bug 1986570: drop operand images as required field on CRD

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -16,6 +16,8 @@ limitations under the License.
 package v1
 
 import (
+	"os"
+
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -96,7 +98,12 @@ func init() {
 
 // ImagePath returns a compiled full valid image string
 func (o *OperandSpec) ImagePath() string {
-	return o.Image
+	if o.Image != "" {
+		return o.Image
+	}
+
+	image := os.Getenv("NODE_FEATURE_DISCOVERY_IMAGE")
+	return image
 }
 
 // ImagePolicy returns a valid corev1.PullPolicy from the string in the CR

--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -24,6 +24,7 @@ import (
 // NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
 // +k8s:openapi-gen=true
 type NodeFeatureDiscoverySpec struct {
+	// +optional
 	Operand      OperandSpec `json:"operand"`
 	WorkerConfig ConfigMap   `json:"workerConfig"`
 

--- a/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: nodefeaturediscoveries.nfd.openshift.io
 spec:
@@ -78,7 +78,6 @@ spec:
                 - configData
                 type: object
             required:
-            - operand
             - workerConfig
             type: object
           status:

--- a/manifests/4.8/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/manifests/4.8/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.6.1
   creationTimestamp: null
   name: nodefeaturediscoveries.nfd.openshift.io
 spec:
@@ -17,13 +18,18 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: NodeFeatureDiscovery is the Schema for the nodefeaturediscoveries API
+        description: NodeFeatureDiscovery is the Schema for the nodefeaturediscoveries
+          API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -31,7 +37,8 @@ spec:
             description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
               customConfig:
-                description: ConfigMap describes configuration options for the NFD worker
+                description: ConfigMap describes configuration options for the NFD
+                  worker
                 properties:
                   configData:
                     description: BinaryData holds the NFD configuration file
@@ -45,19 +52,23 @@ spec:
                 description: OperandSpec describes configuration options for the operand
                 properties:
                   image:
-                    description: Image defines the image to pull for the NFD operand [defaults to quay.io/openshift/origin-node-feature-discovery]
+                    description: Image defines the image to pull for the NFD operand
+                      [defaults to quay.io/openshift/origin-node-feature-discovery]
                     pattern: '[a-zA-Z0-9\-]+'
                     type: string
                   imagePullPolicy:
-                    description: ImagePullPolicy defines Image pull policy for the NFD operand image [defaults to Always]
+                    description: ImagePullPolicy defines Image pull policy for the
+                      NFD operand image [defaults to Always]
                     type: string
                   namespace:
-                    description: Namespace defines the namespace to deploy nfd-master and nfd-worker pods
+                    description: Namespace defines the namespace to deploy nfd-master
+                      and nfd-worker pods
                     pattern: '[a-zA-Z0-9\.\-\/]+'
                     type: string
                 type: object
               workerConfig:
-                description: ConfigMap describes configuration options for the NFD worker
+                description: ConfigMap describes configuration options for the NFD
+                  worker
                 properties:
                   configData:
                     description: BinaryData holds the NFD configuration file
@@ -66,16 +77,18 @@ spec:
                 - configData
                 type: object
             required:
-            - operand
             - workerConfig
             type: object
           status:
-            description: NodeFeatureDiscoveryStatus defines the observed state of NodeFeatureDiscovery
+            description: NodeFeatureDiscoveryStatus defines the observed state of
+              NodeFeatureDiscovery
             properties:
               conditions:
-                description: Conditions represents the latest available observations of current state.
+                description: Conditions represents the latest available observations
+                  of current state.
                 items:
-                  description: Condition represents the state of the operator's reconciliation functionality.
+                  description: Condition represents the state of the operator's reconciliation
+                    functionality.
                   properties:
                     lastHeartbeatTime:
                       format: date-time
@@ -90,7 +103,8 @@ spec:
                     status:
                       type: string
                     type:
-                      description: ConditionType is the state of the operator's reconciliation functionality.
+                      description: ConditionType is the state of the operator's reconciliation
+                        functionality.
                       type: string
                   required:
                   - status


### PR DESCRIPTION
Patch based on https://github.com/openshift/cluster-nfd-operator/pull/187 with minor changes to accommodate to past release, automated cherry-pick was not possible due to newer changes on current release 

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>