### PR TITLE
Fix the controller manager's logic for updating resources

### DIFF
--- a/controllers/nodefeaturediscovery_controller.go
+++ b/controllers/nodefeaturediscovery_controller.go
@@ -28,17 +28,20 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 
 	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 	nfdMetrics "github.com/openshift/cluster-nfd-operator/pkg/metrics"
 )
+//	"sigs.k8s.io/controller-runtime/pkg/handler"
+//	"sigs.k8s.io/controller-runtime/pkg/source"
+//	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 var log = logf.Log.WithName("controller_nodefeaturediscovery")
 
@@ -75,37 +78,392 @@ type NodeFeatureDiscoveryReconciler struct {
 // NodeFeatureDiscoveryReconciler struct.
 func (r *NodeFeatureDiscoveryReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
-	// we want to initate reconcile loop only on spec change of the object
-	p := predicate.Funcs{
+	// For handling the the creation, deletion, and updates of DaemonSet objects
+	dsPredicateFuncs := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 
-			// First, determine if there are any NFD Operator resource
-			// updates. If not, return false so that the reconciler
-			// knows not to attempt an update on a resource that
-			// doesn't need an update.
-			if !validateUpdateEvent(&e) {
+			// Extract the old and new DaemonSet objects. If either one
+			// doesn't exist, then no update occurred, so return 'false'.
+			oldDsObject, ok := e.ObjectOld.(*appsv1.DaemonSet)
+			if !ok {
 				return false
 			}
 
-			// If there were updates, make sure that the old and new
-			// versions of the resource are indeed different. Otherwise,
-			// we don't have a 'true' update. (i.e., We don't want to
-			// call the reconciler again since the resource wasn't
-			// actually changed.)
-			return e.ObjectNew.GetGeneration() != e.ObjectOld.GetGeneration() ||
-				!apiequality.Semantic.DeepEqual(e.ObjectNew.GetLabels(), e.ObjectOld.GetLabels())
+			newDsObject, ok := e.ObjectNew.(*appsv1.DaemonSet)
+			if !ok {
+				return false
+			}
+
+			// Get the deletion timestamps. If they're the same, then no update
+			// has been made.
+			oldDeletionTimestamp := oldDsObject.GetDeletionTimestamp()
+			newDeletionTimestamp := newDsObject.GetDeletionTimestamp()
+			if (oldDeletionTimestamp == newDeletionTimestamp) {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			if newDsObject.GetGeneration() == oldDsObject.GetGeneration(){
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the DaemonSet object has been created already.
+			_, ok := e.Object.(*appsv1.DaemonSet)
+			if !ok {
+				return false
+			}
+			return true
+		},
+	}
+
+	// For handling the the creation, deletion, and updates of ServiceAccount objects
+	saPredicateFuncs := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			// Extract the old and new ServiceAccount objects. If either one
+			// doesn't exist, then no update occurred, so return 'false'.
+			oldSaObject, ok := e.ObjectOld.(*corev1.ServiceAccount)
+			if !ok {
+				return false
+			}
+
+			newSaObject, ok := e.ObjectNew.(*corev1.ServiceAccount)
+			if !ok {
+				return false
+			}
+
+			// Get the deletion timestamps. If they're the same, then no update
+			// has been made.
+			oldDeletionTimestamp := oldSaObject.GetDeletionTimestamp()
+			newDeletionTimestamp := newSaObject.GetDeletionTimestamp()
+			if (oldDeletionTimestamp == newDeletionTimestamp) {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			if newSaObject.GetGeneration() == oldSaObject.GetGeneration(){
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the ServiceAccount object has been created already.
+			_, ok := e.Object.(*corev1.ServiceAccount)
+			if !ok {
+				return false
+			}
+			return true
+		},
+	}
+
+	// For handling the the creation, deletion, and updates of Service objects
+	svcPredicateFuncs := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			// Extract the old and new Service objects. If either one doesn't
+			// exist, then no update occurred, so return 'false'.
+			oldSvcObject, ok := e.ObjectOld.(*corev1.Service)
+			if !ok {
+				return false
+			}
+
+			newSvcObject, ok := e.ObjectNew.(*corev1.Service)
+			if !ok {
+				return false
+			}
+
+			// Get the deletion timestamps. If they're the same, then no update
+			// has been made.
+			oldDeletionTimestamp := oldSvcObject.GetDeletionTimestamp()
+			newDeletionTimestamp := newSvcObject.GetDeletionTimestamp()
+			if (oldDeletionTimestamp == newDeletionTimestamp) {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			if newSvcObject.GetGeneration() == oldSvcObject.GetGeneration(){
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the Service object has been created already.
+			_, ok := e.Object.(*corev1.Service)
+			if !ok {
+				return false
+			}
+			return true
+		},
+	}
+
+	// For handling the the creation, deletion, and updates of RoleBinding objects
+	rbPredicateFuncs := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			// Extract the old and new RoleBinding objects. If either one
+			// doesn't exist, then no update occurred, so return 'false'.
+			oldRbObject, ok := e.ObjectOld.(*rbacv1.RoleBinding)
+			if !ok {
+				return false
+			}
+
+			newRbObject, ok := e.ObjectNew.(*rbacv1.RoleBinding)
+			if !ok {
+				return false
+			}
+
+			// Get the deletion timestamps. If they're the same, then no update
+			// has been made.
+			oldDeletionTimestamp := oldRbObject.GetDeletionTimestamp()
+			newDeletionTimestamp := newRbObject.GetDeletionTimestamp()
+			if (oldDeletionTimestamp == newDeletionTimestamp) {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			if newRbObject.GetGeneration() == oldRbObject.GetGeneration(){
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the RoleBinding object has been created already.
+			_, ok := e.Object.(*rbacv1.RoleBinding)
+			if !ok {
+				return false
+			}
+			return true
+		},
+	}
+
+	// For handling the the creation, deletion, and updates of Role objects
+	rPredicateFuncs := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			// Extract the old and new Role objects. If either one doesn't
+			// exist, then no update occurred, so return false.
+			oldRObject, ok := e.ObjectOld.(*rbacv1.Role)
+			if !ok {
+				return false
+			}
+
+			newRObject, ok := e.ObjectNew.(*rbacv1.Role)
+			if !ok {
+				return false
+			}
+
+			// Get the deletion timestamps. If they're the same, then no update
+			// has been made.
+			oldDeletionTimestamp := oldRObject.GetDeletionTimestamp()
+			newDeletionTimestamp := newRObject.GetDeletionTimestamp()
+			if (oldDeletionTimestamp == newDeletionTimestamp) {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			if newRObject.GetGeneration() == oldRObject.GetGeneration(){
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the Role object has been created already.
+			_, ok := e.Object.(*rbacv1.Role)
+			if !ok {
+				return false
+			}
+			return true
+		},
+	}
+
+	// For handling the the creation, deletion, and updates of ConfigMap objects
+	cmPredicateFuncs := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			// Extract the old and new ConfigMap objects. If either
+			// one doesn't exist, then no update occurred, so return
+			// 'false'.
+			oldCmObject, ok := e.ObjectOld.(*corev1.ConfigMap)
+			if !ok {
+				return false
+			}
+
+			newCmObject, ok := e.ObjectNew.(*corev1.ConfigMap)
+			if !ok {
+				return false
+			}
+
+			// Get the deletion timestamps. If they're the same, then no update
+			// has been made.
+			oldDeletionTimestamp := oldCmObject.GetDeletionTimestamp()
+			newDeletionTimestamp := newCmObject.GetDeletionTimestamp()
+			if (oldDeletionTimestamp == newDeletionTimestamp) {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			if newCmObject.GetGeneration() == oldCmObject.GetGeneration(){
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the ConfigMap object has been created already.
+			_, ok := e.Object.(*corev1.ConfigMap)
+			if !ok {
+				return false
+			}
+			return true
+		},
+	}
+
+	// For handling the the creation, deletion, and updates of SecurityContextConstraints
+	// objects
+	sccPredicateFuncs := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			// Extract the old and new SecurityContextConstraints objects. If
+			// either one doesn't exist, then no update occurred, return 'false'.
+			oldSccObject, ok := e.ObjectOld.(*security.SecurityContextConstraints)
+			if !ok {
+				return false
+			}
+
+			newSccObject, ok := e.ObjectNew.(*security.SecurityContextConstraints)
+			if !ok {
+				return false
+			}
+
+			// Get the deletion timestamps. If they're the same, then no update
+			// has been made.
+			oldDeletionTimestamp := oldSccObject.GetDeletionTimestamp()
+			newDeletionTimestamp := newSccObject.GetDeletionTimestamp()
+			if (oldDeletionTimestamp == newDeletionTimestamp) {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			if newSccObject.GetGeneration() == oldSccObject.GetGeneration(){
+				return false
+			}
+
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the SecurityContextConstraints object has been
+			// created already.
+			_, ok := e.Object.(*security.SecurityContextConstraints)
+			if !ok {
+				return false
+			}
+			return true
+		},
+	}
+
+	// For handling the the creation, deletion, and updates of NFD instances
+	nfdPredicateFuncs := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			// Extract the old and new NodeFeatureDiscovery instances. If
+			// either one doesn't exist, then no update occurred, return 'false'.
+			oldNfdObject, ok := e.ObjectOld.(*nfdv1.NodeFeatureDiscovery)
+			if !ok {
+				return false
+			}
+
+			newNfdObject, ok := e.ObjectNew.(*nfdv1.NodeFeatureDiscovery)
+			if !ok {
+				return false
+			}
+
+			// If everything else is the same, then no update has been made
+			// either.
+			return oldNfdObject.GetGeneration() != newNfdObject.GetGeneration() ||
+				!apiequality.Semantic.DeepEqual(oldNfdObject.GetLabels(), newNfdObject.GetLabels())
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+
+			// Evaluates to false if the object has been deleted
+			return !e.DeleteStateUnknown
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+
+			// Check if the NodeFeatureDiscovery instance has been created
+			// already.
+			_, ok := e.Object.(*nfdv1.NodeFeatureDiscovery)
+			if !ok {
+				return false
+			}
+			return true
 		},
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&nfdv1.NodeFeatureDiscovery{}).
-		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(p)).
-		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(p)).
-		Owns(&rbacv1.Role{}, builder.WithPredicates(p)).
-		Owns(&corev1.Service{}, builder.WithPredicates(p)).
-		Owns(&appsv1.DaemonSet{}, builder.WithPredicates(p)).
-		Owns(&corev1.ConfigMap{}, builder.WithPredicates(p)).
-		Owns(&security.SecurityContextConstraints{}).
+		For(&nfdv1.NodeFeatureDiscovery{}, builder.WithPredicates(nfdPredicateFuncs)).
+		Owns(&corev1.ServiceAccount{}, builder.WithPredicates(saPredicateFuncs)).
+		Owns(&rbacv1.RoleBinding{}, builder.WithPredicates(rbPredicateFuncs)).
+		Owns(&rbacv1.Role{}, builder.WithPredicates(rPredicateFuncs)).
+		Owns(&corev1.Service{}, builder.WithPredicates(svcPredicateFuncs)).
+		Owns(&appsv1.DaemonSet{}, builder.WithPredicates(dsPredicateFuncs)).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(cmPredicateFuncs)).
+		Owns(&security.SecurityContextConstraints{}, builder.WithPredicates(sccPredicateFuncs)).
 		Complete(r)
 }
 

--- a/controllers/nodefeaturediscovery_controller.go
+++ b/controllers/nodefeaturediscovery_controller.go
@@ -28,20 +28,17 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 
 	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 	nfdMetrics "github.com/openshift/cluster-nfd-operator/pkg/metrics"
 )
-//	"sigs.k8s.io/controller-runtime/pkg/handler"
-//	"sigs.k8s.io/controller-runtime/pkg/source"
-//	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 var log = logf.Log.WithName("controller_nodefeaturediscovery")
 


### PR DESCRIPTION
The NFD Operator attempts to check if one or more of its resources have been updated by determining whether or not a recorded event has "old" and "new" versions of the same resources. However, the logic should not end there. The Operator should also determine if the old and new versions are *actually* different. In other words, the operator may see "two versions" of the same resource and thus think that a change occurred, but both "versions" of the resource *may actually be identical*, which means an update didn't actually occur. So, we want to make sure that the operator's reconciler doesn't attempt to update something that doesn't need updating, as we don't want the reconciler unnecessarily being called multiple times when no update is required.