### PR TITLE
Consolidate code for finalizers and CR status updates

### DIFF
--- a/controllers/nodefeaturediscovery_controller.go
+++ b/controllers/nodefeaturediscovery_controller.go
@@ -584,13 +584,22 @@ func (r *NodeFeatureDiscoveryReconciler) Reconcile(ctx context.Context, req ctrl
 		return reconcile.Result{}, err
 	}
 
-	// Check the status of the NFD Operator ServiceAccount
-	rstatus, err := r.getServiceAccountConditions(ctx)
+	// Check the status of the NFD Operator worker ServiceAccount
+	rstatus, err := r.getWorkerServiceAccountConditions(ctx)
 	if rstatus.isDegraded == true {
 		return r.updateDegradedCondition(instance, err.Error(), err)
 
 	} else if err != nil {
-		return r.updateDegradedCondition(instance, conditionFailedGettingNFDServiceAccount, err)
+		return r.updateDegradedCondition(instance, conditionFailedGettingNFDWorkerServiceAccount, err)
+	}
+
+	// Check the status of the NFD Operator master ServiceAccount
+	rstatus, err = r.getMasterServiceAccountConditions(ctx)
+	if rstatus.isDegraded == true {
+		return r.updateDegradedCondition(instance, err.Error(), err)
+
+	} else if err != nil {
+		return r.updateDegradedCondition(instance, conditionFailedGettingNFDMasterServiceAccount, err)
 	}
 
 	// Check the status of the NFD Operator role


### PR DESCRIPTION
Currently, the same logic is being used for updating the NFD instance CR, as well as adding and removing finalizers. However, the code for this logic is repeated. Thus, the aim of this PR is to consolidate the code so that the logic is not repeated, but instead reused for all situations.

Note that I also added code to check for master and worker service accounts, as the previous PR for updating the NFD CRD status only checked for the master service account, not the worker service account too.

Finally, I also added code to initialize a resource's status to "isDegraded" instead of having the same code repeated a number of times in the `controllers/nodefeaturediscovery_status.go` code.