### PR TITLE
Bug 2009812: Remove namespace from controller-manager-alerts-monitor

### DIFF
--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -57,7 +57,6 @@ metadata:
   labels:
     role: alert-rules
   name: controller-manager-alerts-monitor
-  namespace: openshift-nfd
 spec:
   groups:
   - name: node-feature-discovery-operator.rules

--- a/manifests/4.9/manifests/nfd-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/manifests/4.9/manifests/nfd-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     role: alert-rules
   name: controller-manager-alerts-monitor
-  namespace: openshift-nfd
 spec:
   groups:
   - name: node-feature-discovery-operator.rules


### PR DESCRIPTION
This line is causing:

Error: Value controller-manager-alerts-monitor: error validating object:
metadata.namespace: Forbidden: not allowed on this type.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>