### PR TITLE
CSV: fix kube-rbac-proxy image reference

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -13,4 +13,4 @@ spec:
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+      name: registry.redhat.io/openshift4/ose-kube-rbac-proxy


### PR DESCRIPTION
This PR fixes the kube-rbac-proxy image reference used by the NFD Operator. Without this fix, the image is referenced by an implicit `latest` tag, and this breaks disconnected deployment, which requires a SHA image reference.

`registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.10` is the string [used](https://github.com/openshift/cluster-nfd-operator/blob/c8d4be46e46622f1f29479cedac4a020d73bc08b/manifests/image-references) in `manifests/image-reference` for the `kube-rbac-proxy` image. This string will be replaced (by ART) by the image+SHA.

WARNING: I'm not sure how to test this :(