### PR TITLE
Bug 2022496: NFD operator failing greenwave CVP tests

### DIFF
--- a/manifests/4.10/manifests/nfd-operator_v1_serviceaccount.yaml
+++ b/manifests/4.10/manifests/nfd-operator_v1_serviceaccount.yaml
@@ -1,5 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  creationTimestamp: null
-  name: nfd-operator


### PR DESCRIPTION
OLM manages the lifecycle of the serviceaccount which is specified in
the CSV.
If it's added again as a separate manifest it may interfere and cause
issues with OLM’s management process (like causing upgrade failures
etc). That's the reason it need not be added by the user separately.
The suggested action is to remove the service account config yaml file
from the operator’s manifest folder.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>