### PR TITLE
[release-4.10] Bug 2055244: Do not set explicitly image pull policy to Always

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,6 @@ spec:
             - "--zap-encoder=console"
             - "--zap-log-level=debug"
           image: controller:latest
-          imagePullPolicy: Always
           env:
             - name: SSL_CERT_DIR
               value: "/etc/pki/tls/certs"

--- a/config/manifests/bases/nfd.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd.clusterserviceversion.yaml
@@ -17,7 +17,6 @@ metadata:
             },
             "operand": {
               "image": "quay.io/openshift/origin-node-feature-discovery:4.10",
-              "imagePullPolicy": "Always",
               "servicePort": 12000
             },
             "workerConfig": {
@@ -746,7 +745,6 @@ spec:
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
                   value: quay.io/openshift/origin-node-feature-discovery:4.10
                 image: quay.io/openshift/origin-cluster-nfd-operator:4.10
-                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
@@ -12,7 +12,6 @@ spec:
   #  - "example.com/resource"
   operand:
     image: quay.io/openshift/origin-node-feature-discovery:4.10
-    imagePullPolicy: Always
     servicePort: 12000
   workerConfig:
     configData: |

--- a/manifests/4.10/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/4.10/manifests/nfd.clusterserviceversion.yaml
@@ -17,7 +17,6 @@ metadata:
             },
             "operand": {
               "image": "quay.io/openshift/origin-node-feature-discovery:4.10",
-              "imagePullPolicy": "Always",
               "servicePort": 12000
             },
             "workerConfig": {
@@ -797,7 +796,6 @@ spec:
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
                   value: quay.io/openshift/origin-node-feature-discovery:4.10
                 image: quay.io/openshift/origin-cluster-nfd-operator:4.10
-                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
In Telco far edge use case, a cluster might have limited management bandwidth.
Upgrading such a cluster is expected to be time-limited (capped by a maintenance window) and will involve container image pre-caching on the node.

Image pre-caching solution for nodes with limited management bandwidth relies on the assumption, that workloads can use locally stored images without contacting a registry. This is possible if the container image pull policy is set to "IfNotPresent".
The NFD operator is using Always as the pull policy, we should delete the policy and have the default behavior.

From https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting

When you (or a controller) submit a new Pod to the API server, your cluster sets the image pull policy field when specific conditions are met:

if you omit the imagePullPolicy field, and the tag for the container image is :latest, imagePullPolicy is automatically set to Always

if you omit the imagePullPolicy field, and you don't specify the tag for the container image, imagePullPolicy is automatically set to Always;

if you omit the imagePullPolicy field, and you specify the tag for the container image that isn't :latest, the imagePullPolicy is automatically set to IfNotPresent.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>