### PR TITLE
Bug 2089962: update version to 4.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make build
 # Create production image for running the operator
 FROM registry.ci.openshift.org/ocp/4.11:base
 
-ARG CSV=4.10
+ARG CSV=4.11
 COPY --from=builder /go/src/github.com/openshift/cluster-nfd-operator/node-feature-discovery-operator /
 
 RUN mkdir -p /opt/nfd

--- a/config/manifests/bases/nfd.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
               "configData": "#    - name: \"more.kernel.features\"\n#      matchOn:\n#      - loadedKMod: [\"example_kmod3\"]\n#    - name: \"more.features.by.nodename\"\n#      value: customValue\n#      matchOn:\n#      - nodename: [\"special-.*-node-.*\"]\n"
             },
             "operand": {
-              "image": "quay.io/openshift/origin-node-feature-discovery:4.10",
+              "image": "quay.io/openshift/origin-node-feature-discovery:4.11",
               "imagePullPolicy": "Always",
               "servicePort": 12000
             },
@@ -66,7 +66,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Integration & Delivery,OpenShift Optional
-    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.10
+    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.11
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.
 

--- a/manifests/4.11/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/4.11/manifests/nfd.clusterserviceversion.yaml
@@ -65,7 +65,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Integration & Delivery,OpenShift Optional
-    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.10
+    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.11
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.
 
@@ -794,8 +794,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
-                  value: quay.io/openshift/origin-node-feature-discovery:4.10
-                image: quay.io/openshift/origin-cluster-nfd-operator:4.10
+                  value: quay.io/openshift/origin-node-feature-discovery:4.11
+                image: quay.io/openshift/origin-cluster-nfd-operator:4.11
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	nodeFeatureDiscoveryImageDefault string = "quay.io/openshift/origin-node-feature-discovery:4.10"
+	nodeFeatureDiscoveryImageDefault string = "quay.io/openshift/origin-node-feature-discovery:4.11"
 	contextTimeout                          = 300 * time.Second
 	// A number in seconds to define a context Timeout
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ limitations under the License.
 package version
 
 var (
-	Version = "4.10.0"
+	Version = "4.11.0"
 )


### PR DESCRIPTION
The image-references must exactly match in order for ART substitutions to take place.

/cc @ArangoGutierrez 