### PR TITLE
Remove generation check in NFD update predicate

### DIFF
--- a/controllers/nodefeaturediscovery_finalizers.go
+++ b/controllers/nodefeaturediscovery_finalizers.go
@@ -76,8 +76,8 @@ func (r *NodeFeatureDiscoveryReconciler) addFinalizer(ctx context.Context, insta
 		return ctrl.Result{}, err
 	}
 
-	// we exit reconcile loop because we will have additional update reconcile
-	return ctrl.Result{Requeue: false}, nil
+	// we exit reconcile loop and explicitly requeue to continue reconciliation
+	return ctrl.Result{Requeue: true}, nil
 }
 
 // hasFinalizer determines if the operand has a certain finalizer.


### PR DESCRIPTION
This PR removes the update predicate that checks for the change of the `.metadata.generation` field of the NFD CR, in order to be able to fully reconcile a created NFD CR after its finalizer and status is updated.

### Context
According to the Kubernetes documentation, `.metadata` or `.status` updates do not bump the `.metadata.generation` of an object. This leads to the NFD CR not being fully reconciled after its creation, i.e. after the addition of its finalizer and the update of its `.status`, there is no additional update reconciliation event queued. The cause is the update predicate used to check for the difference between the `.metadata.generation` field of the old and new NFD objects.

### `kubectl` vs Kubernetes Go client
This issue cannot be reproduced using `kubectl` (not sure yet why that is), but it is reproducible by using a Kubernetes Go client (e.g. by creating a new NFD CR via another `controller-runtime`-based operator).

### Resources
- https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource

> The `.metadata.generation` value is incremented for all changes, except for changes to `.metadata` or `.status`.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>