### PR TITLE
Allow multiple NFD CR in the cluster

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ import (
 
 	nfdopenshiftv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 	"github.com/openshift/cluster-nfd-operator/controllers"
-	"github.com/openshift/cluster-nfd-operator/pkg/utils"
 	"github.com/openshift/cluster-nfd-operator/pkg/version"
 	// +kubebuilder:scaffold:imports
 )
@@ -90,12 +89,6 @@ func main() {
 		os.Exit(0)
 	}
 
-	watchNamespace, envSet := utils.GetWatchNamespace()
-	if !envSet {
-		klog.Info("unable to get WatchNamespace, " +
-			"the manager will watch and manage resources in all namespaces")
-	}
-
 	// Create a new manager to manage the operator
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -104,7 +97,6 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         args.enableLeaderElection,
 		LeaderElectionID:       "39f5e5c3.nodefeaturediscoveries.nfd.openshift.io",
-		Namespace:              watchNamespace,
 	})
 
 	if err != nil {


### PR DESCRIPTION
This PR allows supporting different NFD CRs in the running cluster. Currently NFD supports only one NFD CRs per namespace, and it only watches the namespace it was deployed into. This PR supplies the final brick to allow deploying additional NFD CRs, each one in its own namespace. 1) NFD operator should watch cluster-wide namespaces 2) on each new CR a master/worker will be deployed in the
   correlated namespace, with the appropriate Role/RoleBinding
3) NFD will rely on the ClusterRole/ClusterRoleBinding/SCC
   deployed by the first CR

This implementation will probably be changed in the future, once we consolidate multiple CRs issues in the upstream.