### PR TITLE
Changing kustomize version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ controller-gen:
 # Download kustomize locally if necessary
 KUSTOMIZE = $(PROJECT_DIR)/bin/kustomize
 kustomize:
-	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.10.0)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
 
 # go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool


### PR DESCRIPTION
Makefile has moved from "go get" to "go install" method of installing needed packages, including kustomize. Kustomize version needs to be updated to a newer one, where go.mod does not include replace/exclude directives