### PR TITLE
Adding pod security label for NFD namespace

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
   name: openshift-nfd
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
Starting from 4.12 the openshift-nfd namespace needs a label to allow pod security privilidged level for nfd worker In case NFD is deployed to a different namespace, OCP operator will add the needed label ( it ignores all namespaces starting with openshift)