### PR TITLE
Fixing ART build failure in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ go_mod:
 	@go mod download
 
 # Build binary
-build: go_mod
+build:
 	@GOOS=$(GOOS) GO111MODULE=on CGO_ENABLED=0 $(GO_CMD) build -o $(BIN) $(LDFLAGS) $(MAIN_PACKAGE)
 
 # Run against the configured Kubernetes cluster in ~/.kube/config


### PR DESCRIPTION
ART is running in disconnected environment. build target was depended on go_mod target which executes go mod download. In order for ART to use vendor directory as is, build must not depend on go_mod