### PR TITLE
Fixing the discrepency between the NFD yaml and the API

### DIFF
--- a/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: nodefeaturediscoveries.nfd.openshift.io
 spec:
@@ -107,13 +106,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/crd/bases/nfd.openshift.io_v1_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.openshift.io_v1_nodefeaturediscoveries.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: nodefeaturediscoveries.nfd.openshift.io
 spec:
@@ -19,7 +18,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: An Node Feature Discovery cluster instance
+        description: NodeFeatureDiscovery is the Schema for the nodefeaturediscoveries
+          API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -34,19 +34,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: Specification of the desired behavior of the Node Feature
-              Discovery
+            description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
-              customConfig:
-                description: WorkerConfig describes configuration options for the
-                  NFD worker.
-                properties:
-                  configData:
-                    description: BinaryData holds the NFD configuration file
-                    type: string
-                required:
-                - configData
-                type: object
               extraLabelNs:
                 description: ExtraLabelNs defines the list of of allowed extra label
                   namespaces By default, only allow labels in the default `feature.node.kubernetes.io`
@@ -56,8 +45,8 @@ spec:
                 nullable: true
                 type: array
               instance:
-                description: Run NFD in multiple deployment mode https://kubernetes-sigs.github.io/node-feature-discovery/v0.8/advanced/master-commandline-reference.html#-instance
-                nullable: true
+                description: Instance name. Used to separate annotation namespaces
+                  for multiple parallel deployments.
                 type: string
               labelWhiteList:
                 description: LabelWhiteList defines a regular expression for filtering
@@ -70,7 +59,7 @@ spec:
                 properties:
                   image:
                     description: Image defines the image to pull for the NFD operand
-                    nullable: true
+                      [defaults to k8s.gcr.io/nfd/node-feature-discovery]
                     pattern: '[a-zA-Z0-9\-]+'
                     type: string
                   imagePullPolicy:
@@ -89,11 +78,15 @@ spec:
                   type: string
                 nullable: true
                 type: array
-              topologyupdater:
+              topologyUpdater:
+                description: Deploy the NFD-Topology-Updater NFD-Topology-Updater
+                  is a daemon responsible for examining allocated resources on a worker
+                  node to account for resources available to be allocated to new pod
+                  on a per-zone basis https://kubernetes-sigs.github.io/node-feature-discovery/v0.10/get-started/introduction.html#nfd-topology-updater
                 type: boolean
               workerConfig:
-                description: ConfigMap describes configuration options for the NFD
-                  worker
+                description: WorkerConfig describes configuration options for the
+                  NFD worker.
                 properties:
                   configData:
                     description: BinaryData holds the NFD configuration file
@@ -113,13 +106,12 @@ spec:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
                     use as an array at the field path .status.conditions.  For example,
-                    type FooStatus struct{     // Represents the observations of a
-                    foo's current state.     // Known .status.conditions.type are:
-                    \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                    \    // +patchStrategy=merge     // +listType=map     // +listMapKey=type
-                    \    Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                    \n     // other fields }"
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
                     lastTransitionTime:
                       description: lastTransitionTime is the last time the condition

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/manifests/4.12/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/manifests/4.12/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -1,8 +1,9 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: nodefeaturediscoveries.nfd.openshift.io
 spec:
@@ -17,7 +18,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: An Node Feature Discovery cluster instance
+        description: NodeFeatureDiscovery is the Schema for the nodefeaturediscoveries
+          API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -32,19 +34,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: Specification of the desired behavior of the Node Feature
-              Discovery
+            description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
-              customConfig:
-                description: WorkerConfig describes configuration options for the
-                  NFD worker.
-                properties:
-                  configData:
-                    description: BinaryData holds the NFD configuration file
-                    type: string
-                required:
-                - configData
-                type: object
               extraLabelNs:
                 description: ExtraLabelNs defines the list of of allowed extra label
                   namespaces By default, only allow labels in the default `feature.node.kubernetes.io`
@@ -54,8 +45,8 @@ spec:
                 nullable: true
                 type: array
               instance:
-                description: Run NFD in multiple deployment mode https://kubernetes-sigs.github.io/node-feature-discovery/v0.8/advanced/master-commandline-reference.html#-instance
-                nullable: true
+                description: Instance name. Used to separate annotation namespaces
+                  for multiple parallel deployments.
                 type: string
               labelWhiteList:
                 description: LabelWhiteList defines a regular expression for filtering
@@ -68,13 +59,12 @@ spec:
                 properties:
                   image:
                     description: Image defines the image to pull for the NFD operand
-                    nullable: true
+                      [defaults to k8s.gcr.io/nfd/node-feature-discovery]
                     pattern: '[a-zA-Z0-9\-]+'
                     type: string
                   imagePullPolicy:
                     description: ImagePullPolicy defines Image pull policy for the
                       NFD operand image [defaults to Always]
-                    nullable: true
                     type: string
                   servicePort:
                     description: ServicePort specifies the TCP port that nfd-master
@@ -88,15 +78,15 @@ spec:
                   type: string
                 nullable: true
                 type: array
-              topologyupdater:
+              topologyUpdater:
                 description: Deploy the NFD-Topology-Updater NFD-Topology-Updater
                   is a daemon responsible for examining allocated resources on a worker
                   node to account for resources available to be allocated to new pod
                   on a per-zone basis https://kubernetes-sigs.github.io/node-feature-discovery/v0.10/get-started/introduction.html#nfd-topology-updater
                 type: boolean
               workerConfig:
-                description: ConfigMap describes configuration options for the NFD
-                  worker
+                description: WorkerConfig describes configuration options for the
+                  NFD worker.
                 properties:
                   configData:
                     description: BinaryData holds the NFD configuration file
@@ -113,26 +103,68 @@ spec:
                 description: Conditions represents the latest available observations
                   of current state.
                 items:
-                  description: Condition represents the state of the operator's reconciliation
-                    functionality.
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource. --- This struct is intended for direct
+                    use as an array at the field path .status.conditions.  For example,
+                    type FooStatus struct{ // Represents the observations of a foo's
+                    current state. // Known .status.conditions.type are: \"Available\",
+                    \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                    // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                    `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                    protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
                   properties:
-                    lastHeartbeatTime:
-                      format: date-time
-                      type: string
                     lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another. This should be when
+                        the underlying condition changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
+                      description: message is a human readable message indicating
+                        details about the transition. This may be an empty string.
+                      maxLength: 32768
                       type: string
+                    observedGeneration:
+                      description: observedGeneration represents the .metadata.generation
+                        that the condition was set based upon. For instance, if .metadata.generation
+                        is currently 12, but the .status.conditions[x].observedGeneration
+                        is 9, the condition is out of date with respect to the current
+                        state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
                     reason:
+                      description: reason contains a programmatic identifier indicating
+                        the reason for the condition's last transition. Producers
+                        of specific condition types may define expected values and
+                        meanings for this field, and whether the values are considered
+                        a guaranteed API. The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
                       type: string
                     status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: ConditionType is the state of the operator's reconciliation
-                        functionality.
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        --- Many .condition.type values are consistent across resources
+                        like Available, but because arbitrary conditions can be useful
+                        (see .node.status.conditions), the ability to deconflict is
+                        important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
+                  - lastTransitionTime
+                  - message
+                  - reason
                   - status
                   - type
                   type: object


### PR DESCRIPTION
Currently NFD controller expect the topology flag json tag to be "topologyUpdater". The yaml that is used during deployment is using the old annotation: "topologyupdater". In order to fix, we need to allign the nfd.openshift.io_v1_nodefeaturediscoveries.yaml with the nfd.openshift.io_nodefeaturediscoveries.yaml