### PR TITLE
Fixing NFD CR deletion in case of Topology enablement

### DIFF
--- a/controllers/nodefeaturediscovery_finalizers.go
+++ b/controllers/nodefeaturediscovery_finalizers.go
@@ -134,6 +134,11 @@ func (r *NodeFeatureDiscoveryReconciler) deleteComponents(ctx context.Context, i
 		if err != nil {
 			return err
 		}
+		// Attempt to delete SCC
+		err = r.deleteSecurityContextConstraintsWithRetry(ctx, retryInterval, timeout, instance.ObjectMeta.Namespace, nfdTopologyUpdaterApp)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Attempt to delete worker DaemonSet


### PR DESCRIPTION
In case Topology is enabled, deleting NFD CR will stuck, because validation if all the resources have been deleted fill fail, due to topology SCC still being present in the cluster This PR add deletion of topology SCC in the finalizers