### PR TITLE
aligning manager watch config with single namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	nfdopenshiftv1 "github.com/openshift/cluster-nfd-operator/api/v1"
+	"github.com/openshift/cluster-nfd-operator/pkg/config"
 	"github.com/openshift/cluster-nfd-operator/controllers"
 	"github.com/openshift/cluster-nfd-operator/pkg/version"
 	// +kubebuilder:scaffold:imports
@@ -89,6 +90,12 @@ func main() {
 		os.Exit(0)
 	}
 
+	watchNamespace, err := config.GetWatchNamespace()
+        if err != nil {
+               klog.Info("unable to get WatchNamespace, " +
+                       "the manager will watch and manage resources in all namespaces")
+        }
+
 	// Create a new manager to manage the operator
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
@@ -97,6 +104,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         args.enableLeaderElection,
 		LeaderElectionID:       "39f5e5c3.nodefeaturediscoveries.nfd.openshift.io",
+		Namespace:              watchNamespace,
 	})
 
 	if err != nil {

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -97,7 +97,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
   name: nfd.v4.13.0
-  namespace: placeholder
+  namespace: openshift-nfd
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:


### PR DESCRIPTION
Since we NFD configuration now supports only single namespace deployment, manager configuration must be watching a specific namespace only, and not all-cluster namespaces