### PR TITLE
Fixing topology pod creation failure

### DIFF
--- a/build/assets/topologyupdater/04_configmap.yaml
+++ b/build/assets/topologyupdater/04_configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nfd-topology-updater-conf
+data:
+  nfd-topology-updater.conf: |
+    #excludeList:
+    ##  node1: [cpu]
+    ##  node2: [memory, example/deviceA]
+    ##  *: [hugepages-2Mi]

--- a/build/assets/topologyupdater/05_Daemonset.yaml
+++ b/build/assets/topologyupdater/05_Daemonset.yaml
@@ -45,6 +45,8 @@ spec:
           name: kubelet-podresources-sock
         - mountPath: /host-sys
           name: host-sys
+        - mountPath: /host-var/lib/kubelet/device-plugins
+          name: kubelete-device-plugins
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccount: nfd-topology-updater
       volumes:
@@ -60,3 +62,7 @@ spec:
           path: /var/lib/kubelet/pod-resources/kubelet.sock
           type: Socket
         name: kubelet-podresources-sock
+      - hostPath:
+          path: /var/lib/kubelet/device-plugins
+          type: Directory
+        name: kubelete-device-plugins

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -344,9 +344,10 @@ func ConfigMap(n NFD) (ResourceStatus, error) {
 	// namespace to the namespace defined in the ConfigMap object
 	obj.SetNamespace(n.ins.GetNamespace())
 
-	// Update ConfigMap
-	obj.ObjectMeta.Name = "nfd-worker"
-	obj.Data["nfd-worker-conf"] = n.ins.Spec.WorkerConfig.ConfigData
+	// Update ConfigMap. In case it is nfd-worker, the config should be taken from NFD CR
+	if obj.ObjectMeta.Name == "nfd-worker" {
+		obj.Data["nfd-worker-conf"] = n.ins.Spec.WorkerConfig.ConfigData
+	}
 
 	// found states if the ConfigMap was found
 	found := &corev1.ConfigMap{}


### PR DESCRIPTION
1) mapping host's device-plugins directory into pod, since it is
   needed now by the kubelet notifier
2) adding topology configmap to the build/assests
3) fixing handling/creation of configmap in the operator. currently it
   is hardcoded supporting only nfd-worker configmap, and this PR
   allows supporting of addition configmaps