### PR TITLE
replace old version numbers with the correct 4.16

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,7 +56,7 @@ spec:
             - name: OPERATOR_NAME
               value: "cluster-nfd-operator"
             - name: NODE_FEATURE_DISCOVERY_IMAGE
-              value: "quay.io/openshift/origin-node-feature-discovery:4.15"
+              value: "quay.io/openshift/origin-node-feature-discovery:4.16"
           ports:
             - name: metrics
               containerPort: 8080

--- a/config/manifests/bases/nfd.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
               "configData": "#    - name: \"more.kernel.features\"\n#      matchOn:\n#      - loadedKMod: [\"example_kmod3\"]\n#    - name: \"more.features.by.nodename\"\n#      value: customValue\n#      matchOn:\n#      - nodename: [\"special-.*-node-.*\"]\n"
             },
             "operand": {
-              "image": "quay.io/openshift/origin-node-feature-discovery:4.15",
+              "image": "quay.io/openshift/origin-node-feature-discovery:4.16",
               "servicePort": 12000
             },
             "workerConfig": {
@@ -65,7 +65,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Integration & Delivery,OpenShift Optional
-    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.15
+    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.16
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.
 
@@ -91,7 +91,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.9.0 <4.15.0'
+    olm.skipRange: '>=4.9.0 <4.16.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-nfd
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -106,7 +106,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: nfd.v4.15.0
+  name: nfd.v4.16.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -807,8 +807,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
-                  value: quay.io/openshift/origin-node-feature-discovery:4.15
-                image: quay.io/openshift/origin-cluster-nfd-operator:4.15
+                  value: quay.io/openshift/origin-node-feature-discovery:4.16
+                image: quay.io/openshift/origin-cluster-nfd-operator:4.16
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -931,7 +931,7 @@ spec:
   - node-labels
   links:
   - name: Node Feature Discovery Operator
-    url: https://docs.openshift.com/container-platform/4.15/hardware_enablement/psap-node-feature-discovery-operator.html
+    url: https://docs.openshift.com/container-platform/4.16/hardware_enablement/psap-node-feature-discovery-operator.html
   - name: Node Feature Discovery Documentation
     url: https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html
   maintainers:
@@ -942,4 +942,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/cluster-nfd-operator
-  version: 4.15.0
+  version: 4.16.0

--- a/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
@@ -11,7 +11,7 @@ spec:
   #resourceLabels:
   #  - "example.com/resource"
   operand:
-    image: quay.io/openshift/origin-node-feature-discovery:4.15
+    image: quay.io/openshift/origin-node-feature-discovery:4.16
     imagePullPolicy: IfNotPresent
     servicePort: 12000
   workerConfig:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,11 +5,11 @@ spec:
   - name: node-feature-discovery
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-node-feature-discovery:4.15
+      name: quay.io/openshift/origin-node-feature-discovery:4.16
   - name: cluster-nfd-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-cluster-nfd-operator:4.15
+      name: quay.io/openshift/origin-cluster-nfd-operator:4.16
   - name: kube-rbac-proxy
     from:
       kind: DockerImage

--- a/manifests/nfd.package.yaml
+++ b/manifests/nfd.package.yaml
@@ -1,5 +1,5 @@
 packageName: nfd
 channels:
 - name: stable
-  currentCSV: nfd.v4.15.0
+  currentCSV: nfd.v4.16.0
 defaultChannel: stable

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
               "configData": "#    - name: \"more.kernel.features\"\n#      matchOn:\n#      - loadedKMod: [\"example_kmod3\"]\n#    - name: \"more.features.by.nodename\"\n#      value: customValue\n#      matchOn:\n#      - nodename: [\"special-.*-node-.*\"]\n"
             },
             "operand": {
-              "image": "quay.io/openshift/origin-node-feature-discovery:4.15",
+              "image": "quay.io/openshift/origin-node-feature-discovery:4.16",
               "servicePort": 12000
             },
             "workerConfig": {
@@ -65,7 +65,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Integration & Delivery,OpenShift Optional
-    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.15
+    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.16
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.
 
@@ -91,7 +91,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.9.0 <4.15.0'
+    olm.skipRange: '>=4.9.0 <4.16.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-nfd
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -106,7 +106,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: nfd.v4.15.0
+  name: nfd.v4.16.0
   namespace: openshift-nfd
 spec:
   apiservicedefinitions: {}
@@ -819,8 +819,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
-                  value: quay.io/openshift/origin-node-feature-discovery:4.15
-                image: quay.io/openshift/origin-cluster-nfd-operator:4.15
+                  value: quay.io/openshift/origin-node-feature-discovery:4.16
+                image: quay.io/openshift/origin-cluster-nfd-operator:4.16
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -943,7 +943,7 @@ spec:
   - node-labels
   links:
   - name: Node Feature Discovery Operator
-    url: https://docs.openshift.com/container-platform/4.15/hardware_enablement/psap-node-feature-discovery-operator.html
+    url: https://docs.openshift.com/container-platform/4.16/hardware_enablement/psap-node-feature-discovery-operator.html
   - name: Node Feature Discovery Documentation
     url: https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html
   maintainers:
@@ -954,4 +954,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/cluster-nfd-operator
-  version: 4.15.0
+  version: 4.16.0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	nodeFeatureDiscoveryImageDefault string = "quay.io/openshift/origin-node-feature-discovery:4.15"
+	nodeFeatureDiscoveryImageDefault string = "quay.io/openshift/origin-node-feature-discovery:4.16"
 	contextTimeout                          = 300 * time.Second
 	// A number in seconds to define a context Timeout
 	// E.g. if 5 seconds is wanted, the CTX_TIMEOUT=5


### PR DESCRIPTION
there are references to the old 4.15 in the 4.16 manifests etc, this PR replaces them with the correct 4.16 version.