### PR TITLE
OCPBUGS-32047: Fix the absence of status from NFD CR (backport PR316)

### DIFF
--- a/controllers/nodefeaturediscovery_finalizers.go
+++ b/controllers/nodefeaturediscovery_finalizers.go
@@ -1,10 +1,9 @@
 /*
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/controllers/nodefeaturediscovery_status.go
+++ b/controllers/nodefeaturediscovery_status.go
@@ -62,6 +62,9 @@ const (
 	conditionNFDClusterRoleDegraded                   = "NFDClusterRoleDegraded"
 	conditionNFDClusterRoleBindingDegraded            = "NFDClusterRoleBindingDegraded"
 
+	// reason for conditions that are currenly false
+	conditionNotBeingMetCurrentlyReason = "ConditionNotBeingMetCurrently"
+
 	// Unknown errors. (Catch all)
 	errorNFDWorkerDaemonSetUnknown = "NFDWorkerDaemonSetCorrupted"
 
@@ -167,21 +170,25 @@ func (r *NodeFeatureDiscoveryReconciler) getAvailableConditions() []metav1.Condi
 		{
 			Type:               ConditionAvailable,
 			Status:             metav1.ConditionTrue,
+			Reason:             "InstanceComponentsAreDeployed",
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
 			Type:               ConditionUpgradeable,
 			Status:             metav1.ConditionTrue,
+			Reason:             "CanBeUpgraded",
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
 			Type:               ConditionProgressing,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
 			Type:               ConditionDegraded,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 	}
@@ -196,16 +203,19 @@ func (r *NodeFeatureDiscoveryReconciler) getDegradedConditions(reason string, me
 		{
 			Type:               ConditionAvailable,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
 			Type:               ConditionUpgradeable,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
 			Type:               ConditionProgressing,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
@@ -227,11 +237,13 @@ func (r *NodeFeatureDiscoveryReconciler) getProgressingConditions(reason string,
 		{
 			Type:               ConditionAvailable,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
 			Type:               ConditionUpgradeable,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 		{
@@ -244,6 +256,7 @@ func (r *NodeFeatureDiscoveryReconciler) getProgressingConditions(reason string,
 		{
 			Type:               ConditionDegraded,
 			Status:             metav1.ConditionFalse,
+			Reason:             conditionNotBeingMetCurrentlyReason,
 			LastTransitionTime: metav1.Time{Time: now},
 		},
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,10 +1,9 @@
 /*
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Backport #316 to the 4.12 branch
for some reason we have a fix in 4.11, 4.13, and later but not 4.12, which has caused some issues for customsers. this backport fixes that

Original message:
Fix the absence of status from NFD CR
Since moving the NFD CR status to use the apimachinery conditions, the reason fields has become non-empty mandatory field. Since it is not set, the update to status is failing, and therefore status is not shown , since it has never been updated.
This PR adds Reason field values to all the conditions

OCPBUGS-7023