### PR TITLE
OCPBUGS-32940: backport the extendedResources etc fields into the rules CRD

### DIFF
--- a/manifests/stable/manifests/nfd.openshift.io_nodefeaturerules.yaml
+++ b/manifests/stable/manifests/nfd.openshift.io_nodefeaturerules.yaml
@@ -11,6 +11,8 @@ spec:
     kind: NodeFeatureRule
     listKind: NodeFeatureRuleList
     plural: nodefeaturerules
+    shortNames:
+    - nfr
     singular: nodefeaturerule
   scope: Namespaced
   versions:
@@ -41,6 +43,16 @@ spec:
                   description: Rule defines a rule for node customization such as
                     labeling.
                   properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: Annotations to create if the rule matches.
+                      type: object
+                    extendedResources:
+                      additionalProperties:
+                        type: string
+                      description: ExtendedResources to create if the rule matches.
+                      type: object
                     labels:
                       additionalProperties:
                         type: string
@@ -186,6 +198,35 @@ spec:
                     name:
                       description: Name of the rule.
                       type: string
+                    taints:
+                      description: Taints to create if the rule matches.
+                      items:
+                        description: The node this Taint is attached to has the "effect"
+                          on any pod that does not tolerate the Taint.
+                        properties:
+                          effect:
+                            description: Required. The effect of the taint on pods
+                              that do not tolerate the taint. Valid effects are NoSchedule,
+                              PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Required. The taint key to be applied to
+                              a node.
+                            type: string
+                          timeAdded:
+                            description: TimeAdded represents the time at which the
+                              taint was added. It is only written for NoExecute taints.
+                            format: date-time
+                            type: string
+                          value:
+                            description: The taint value corresponding to the taint
+                              key.
+                            type: string
+                        required:
+                        - effect
+                        - key
+                        type: object
+                      type: array
                     vars:
                       additionalProperties:
                         type: string


### PR DESCRIPTION
The NodeFeatureRules implementation and docs includes the ability to set `extendedResources`, `annotations`, and `taints` based on matches. The CRD supplied with the release-4.15 operator does not include them, so they are impossible to set in openshift. This backports the master CRD definition (where they are set) back to 4.15.