### PR TITLE
OCPBUGS-33287: set the image to match what art will replace (in image-references)

### DIFF
--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -681,7 +681,7 @@ spec:
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
                   value: quay.io/openshift/origin-node-feature-discovery:4.16
-                image: quay.io/openshift/origin-cluster-nfd-operator:4.16.0
+                image: quay.io/openshift/origin-cluster-nfd-operator:4.16
                 livenessProbe:
                   httpGet:
                     path: /healthz


### PR DESCRIPTION
in manifests/image-references we're set to replace
> quay.io/openshift/origin-cluster-nfd-operator:4.16

with the image built by ART, but in the csv nfd.clusterserviceversion.yaml we have
>image: quay.io/openshift/origin-cluster-nfd-operator:4.16.0

(with an added .0).
Because they differ the CSV is not getting that image updated, so anything installingthe csv is defaulting to an old image that exists for x64 but not for POWER, causing nfd deployments on ppc64le and s390x to fail.