### PR TITLE
OCPBUGS-33741: add the enableTaints option to the discovery resource

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -69,6 +69,12 @@ type NodeFeatureDiscoverySpec struct {
 	// as annotations, extended resources and taints) from the cluster nodes.
 	// +optional
 	PruneOnDelete bool `json:"prunerOnDelete"`
+
+	// EnableTaints enables the enable the experimental tainting feature
+	// This allows keeping nodes with specialized hardware away from running general workload i
+	// and instead leave them for workloads that need the specialized hardware.
+	// +optional
+	EnableTaints bool `json:"enableTaints"`
 }
 
 // OperandSpec describes configuration options for the operand

--- a/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -40,6 +40,12 @@ spec:
           spec:
             description: NodeFeatureDiscoverySpec defines the desired state of NodeFeatureDiscovery
             properties:
+              enableTaints:
+                description: EnableTaints enables the experimental tainting
+                  feature This allows keeping nodes with specialized hardware away
+                  from running general workload and instead leave them for workloads
+                  that need the specialized hardware.
+                type: boolean
               extraLabelNs:
                 description: |-
                   ExtraLabelNs defines the list of of allowed extra label namespaces

--- a/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
@@ -10,6 +10,8 @@ spec:
   #  - "example.com"
   #resourceLabels:
   #  - "example.com/resource"
+  ## NOTE: Taints support is experimental.
+  #enableTaints: true
   operand:
     image: quay.io/openshift/origin-node-feature-discovery:4.16
     imagePullPolicy: IfNotPresent

--- a/controllers/nodefeaturediscovery_controls.go
+++ b/controllers/nodefeaturediscovery_controls.go
@@ -504,6 +504,11 @@ func Deployment(n NFD) (ResourceStatus, error) {
 		args = append(args, fmt.Sprintf("--label-whitelist=%s", n.ins.Spec.LabelWhiteList))
 	}
 
+    if n.ins.Spec.EnableTaints {
+        args = append(args, "--enable-taints")
+    }
+
+
 	obj.Spec.Template.Spec.Containers[0].Args = args
 
 	// Set namespace based on the NFD namespace. (And again,

--- a/manifests/stable/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/manifests/stable/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -83,6 +83,11 @@ spec:
                   node to account for resources available to be allocated to new pod
                   on a per-zone basis https://kubernetes-sigs.github.io/node-feature-discovery/v0.10/get-started/introduction.html#nfd-topology-updater
                 type: boolean
+              enableTaints:
+                description: EnableTaints enables the enable the experimental tainting feature
+                  This allows keeping nodes with specialized hardware away from running general workload
+                  and instead leave them for workloads that need the specialized hardware.
+                type: boolean
               workerConfig:
                 description: WorkerConfig describes configuration options for the
                   NFD worker.


### PR DESCRIPTION
This adds a new option to the NodeFeatureDiscoverySpec `Spec.enableTaints`  when this is set to true it will add the `--enable-taints` flag to the master, allowing NFD to set taints as described in the [upstream docs](https://kubernetes-sigs.github.io/node-feature-discovery/master/usage/customization-guide.html?highlight=Taints#taints)

This option is disabled by default, and not set in the sample configs, as taints support is experimental.  