### PR TITLE
OCPBUGS-31488: add node-feature-rules crd changes from #348 to config

### DIFF
--- a/config/crd/bases/nfd.openshift.io_v1alpha1_nodefeaturerules.yaml
+++ b/config/crd/bases/nfd.openshift.io_v1alpha1_nodefeaturerules.yaml
@@ -11,6 +11,8 @@ spec:
     kind: NodeFeatureRule
     listKind: NodeFeatureRuleList
     plural: nodefeaturerules
+    shortNames:
+    - nfr
     singular: nodefeaturerule
   scope: Namespaced
   versions:
@@ -41,6 +43,11 @@ spec:
                   description: Rule defines a rule for node customization such as
                     labeling.
                   properties:
+                    extendedResources:
+                      additionalProperties:
+                        type: string
+                      description: ExtendedResources to create if the rule matches.
+                      type: object
                     labels:
                       additionalProperties:
                         type: string
@@ -186,6 +193,35 @@ spec:
                     name:
                       description: Name of the rule.
                       type: string
+                    taints:
+                      description: Taints to create if the rule matches.
+                      items:
+                        description: The node this Taint is attached to has the "effect"
+                          on any pod that does not tolerate the Taint.
+                        properties:
+                          effect:
+                            description: Required. The effect of the taint on pods
+                              that do not tolerate the taint. Valid effects are NoSchedule,
+                              PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Required. The taint key to be applied to
+                              a node.
+                            type: string
+                          timeAdded:
+                            description: TimeAdded represents the time at which the
+                              taint was added. It is only written for NoExecute taints.
+                            format: date-time
+                            type: string
+                          value:
+                            description: The taint value corresponding to the taint
+                              key.
+                            type: string
+                        required:
+                        - effect
+                        - key
+                        type: object
+                      type: array
                     vars:
                       additionalProperties:
                         type: string


### PR DESCRIPTION
change to config/crd/bases/nfd.openshift.io_v1alpha1_nodefeaturerules.yaml  adding support for extendedResources and Taints  these changes were  made in  #348  (commit  f136eef)   and were backported into release-4.15 but never made it into 4.14.

This PR backports those changes. 

This is needed for [OCPBUGS-31488](https://issues.redhat.com/browse/OCPBUGS-31488) and were missed in #368 
