### PR TITLE
changing nf crd version from v1 to v1alpha1 

### DIFF
--- a/config/crd/bases/nfd.openshift.io_nodefeaturerules.yaml
+++ b/config/crd/bases/nfd.openshift.io_nodefeaturerules.yaml
@@ -16,7 +16,7 @@ spec:
     singular: nodefeaturerule
   scope: Cluster
   versions:
-  - name: v1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-

--- a/config/crd/bases/nfd.openshift.io_nodefeatures.yaml
+++ b/config/crd/bases/nfd.openshift.io_nodefeatures.yaml
@@ -14,7 +14,7 @@ spec:
     singular: nodefeature
   scope: Namespaced
   versions:
-  - name: v1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
         description: |-


### PR DESCRIPTION
nf cr could not be created on initial deployment due to different versions between the repos, this pr fixes it