### PR TITLE
Fixing kube-rbac-proxy role bindings

### DIFF
--- a/config/rbac/auth_proxy/role_binding.yaml
+++ b/config/rbac/auth_proxy/role_binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: operator
+  name: nfd-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: nfd-manager
+  name: nfd-proxy-role
 subjects:
 - kind: ServiceAccount
   name: nfd-manager


### PR DESCRIPTION
The clusterrolebinding should connect the nfd-proxy-role to the nfd-manager service