### PR TITLE
update the kube-rbac-proxy pullspec to ocp version

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -13,4 +13,4 @@ spec:
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-kube-rbac-proxy
+      name: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -686,7 +686,7 @@ spec:
                 - --tls-cert-file=/etc/secrets/tls.crt
                 - --tls-private-key-file=/etc/secrets/tls.key
                 - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image:  registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443


### PR DESCRIPTION
the kube-rbac-proxy image name that ART is updating when building bundles (defined in manifests/image-references) and the version we are setting in the manifest are out of sync and are both wrong. This PR replaces them both with  `registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16`  which should allow ART to build the bundle correctly and allow it to work with disconnected environments.

It uses the v4.16 version because as yet there is no 4.17 version of the kube-proxy released.

(see #220 for more details)