### PR TITLE
OCPBUGS-39177: change proxy to ose-kube-rbac-proxy-rhel9:v4.16

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -13,4 +13,4 @@ spec:
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-kube-rbac-proxy
+      name: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -686,7 +686,7 @@ spec:
                 - --tls-cert-file=/etc/secrets/tls.crt
                 - --tls-private-key-file=/etc/secrets/tls.key
                 - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443


### PR DESCRIPTION
backport #382 382 to 4.17

set the kube-proxy image in the csv to registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9:v4.16

(see https://github.com/openshift/cluster-nfd-operator/pull/220 for more details)