### PR TITLE
Fixing upgrade from 4.16 to 4.17

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged
   name: openshift-nfd
@@ -13,16 +13,16 @@ metadata:
   name: nfd-controller-manager
   namespace: openshift-nfd
   labels:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: nfd-controller-manager
+      control-plane: controller-manager
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: nfd-controller-manager
+        control-plane: controller-manager
     spec:
       serviceAccountName: nfd-manager
       containers:

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager
   name: nfd-controller-manager-metrics-monitor
   namespace: openshift-nfd
 spec:
@@ -18,7 +18,7 @@ spec:
         serverName: nfd-controller-manager-metrics-service.openshift-nfd.svc
   selector:
     matchLabels:
-      control-plane: nfd-controller-manager
+      control-plane: controller-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/auth_proxy/service.yaml
+++ b/config/rbac/auth_proxy/service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: node-feature-discovery-operator-tls
   labels:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager
   name: nfd-controller-manager-metrics-service
   namespace: openshift-nfd
 spec:
@@ -13,4 +13,4 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager

--- a/manifests/stable/manifests/nfd-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/manifests/stable/manifests/nfd-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager
   name: nfd-controller-manager-metrics-monitor
 spec:
   endpoints:
@@ -16,4 +16,4 @@ spec:
       serverName: nfd-controller-manager-metrics-service.openshift-nfd.svc
   selector:
     matchLabels:
-      control-plane: nfd-controller-manager
+      control-plane: controller-manager

--- a/manifests/stable/manifests/nfd-controller-manager-metrics-service_v1_service.yaml
+++ b/manifests/stable/manifests/nfd-controller-manager-metrics-service_v1_service.yaml
@@ -5,7 +5,7 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: node-feature-discovery-operator-tls
   creationTimestamp: null
   labels:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager
   name: nfd-controller-manager-metrics-service
 spec:
   ports:
@@ -13,6 +13,6 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: nfd-controller-manager
+    control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -664,18 +664,18 @@ spec:
         serviceAccountName: nfd-manager
       deployments:
       - label:
-          control-plane: nfd-controller-manager
+          control-plane: controller-manager
         name: nfd-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: nfd-controller-manager
+              control-plane: controller-manager
           strategy: {}
           template:
             metadata:
               labels:
-                control-plane: nfd-controller-manager
+                control-plane: controller-manager
             spec:
               containers:
               - args:


### PR DESCRIPTION
in 4.17 we have changed the labelling of control plane in deployment and various other object which causes upgrade issues, since labels are immutable. This PR changes the contol-plane labels' values back to the values we had in 4.16