### PR TITLE
bugfix/updating-operand-image

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -82,6 +82,7 @@ type OperandSpec struct {
 	// Image defines the image to pull for the
 	// NFD operand
 	// [defaults to registry.k8s.io/nfd/node-feature-discovery]
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Pattern=[a-zA-Z0-9\-]+
 	Image string `json:"image,omitempty"`
 

--- a/internal/controllers/mock_nodefeaturediscovery_reconciler.go
+++ b/internal/controllers/mock_nodefeaturediscovery_reconciler.go
@@ -54,31 +54,31 @@ func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) finalizeComponents(ctx,
 }
 
 // handleGC mocks base method.
-func (m *MocknodeFeatureDiscoveryHelperAPI) handleGC(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery) error {
+func (m *MocknodeFeatureDiscoveryHelperAPI) handleGC(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, operatorImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleGC", ctx, nfdInstance)
+	ret := m.ctrl.Call(m, "handleGC", ctx, nfdInstance, operatorImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleGC indicates an expected call of handleGC.
-func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleGC(ctx, nfdInstance any) *gomock.Call {
+func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleGC(ctx, nfdInstance, operatorImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleGC", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleGC), ctx, nfdInstance)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleGC", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleGC), ctx, nfdInstance, operatorImage)
 }
 
 // handleMaster mocks base method.
-func (m *MocknodeFeatureDiscoveryHelperAPI) handleMaster(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery) error {
+func (m *MocknodeFeatureDiscoveryHelperAPI) handleMaster(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, operatorImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleMaster", ctx, nfdInstance)
+	ret := m.ctrl.Call(m, "handleMaster", ctx, nfdInstance, operatorImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleMaster indicates an expected call of handleMaster.
-func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleMaster(ctx, nfdInstance any) *gomock.Call {
+func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleMaster(ctx, nfdInstance, operatorImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleMaster", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleMaster), ctx, nfdInstance)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleMaster", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleMaster), ctx, nfdInstance, operatorImage)
 }
 
 // handlePrune mocks base method.
@@ -125,31 +125,31 @@ func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleStatus(ctx, nfdIn
 }
 
 // handleTopology mocks base method.
-func (m *MocknodeFeatureDiscoveryHelperAPI) handleTopology(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery) error {
+func (m *MocknodeFeatureDiscoveryHelperAPI) handleTopology(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, operatorImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleTopology", ctx, nfdInstance)
+	ret := m.ctrl.Call(m, "handleTopology", ctx, nfdInstance, operatorImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleTopology indicates an expected call of handleTopology.
-func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleTopology(ctx, nfdInstance any) *gomock.Call {
+func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleTopology(ctx, nfdInstance, operatorImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleTopology", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleTopology), ctx, nfdInstance)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleTopology", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleTopology), ctx, nfdInstance, operatorImage)
 }
 
 // handleWorker mocks base method.
-func (m *MocknodeFeatureDiscoveryHelperAPI) handleWorker(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery) error {
+func (m *MocknodeFeatureDiscoveryHelperAPI) handleWorker(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, operatorImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleWorker", ctx, nfdInstance)
+	ret := m.ctrl.Call(m, "handleWorker", ctx, nfdInstance, operatorImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleWorker indicates an expected call of handleWorker.
-func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleWorker(ctx, nfdInstance any) *gomock.Call {
+func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleWorker(ctx, nfdInstance, operatorImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleWorker", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleWorker), ctx, nfdInstance)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleWorker", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handleWorker), ctx, nfdInstance, operatorImage)
 }
 
 // hasFinalizer mocks base method.

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -64,7 +64,7 @@ var _ = Describe("SetTopologyDaemonsetAsDesired", func() {
 			},
 		}
 
-		err := daemonsetAPI.SetTopologyDaemonsetAsDesired(ctx, &nfdCR, &topologyDS)
+		err := daemonsetAPI.SetTopologyDaemonsetAsDesired(ctx, &nfdCR, &topologyDS, nfdCR.Spec.Operand.Image)
 
 		Expect(err).To(BeNil())
 		expectedYAMLFile, err := os.ReadFile("testdata/test_topology_daemonset.yaml")
@@ -108,7 +108,7 @@ var _ = Describe("SetWorkerDaemonsetAsDesired", func() {
 			},
 		}
 
-		err := daemonsetAPI.SetWorkerDaemonsetAsDesired(ctx, &nfdCR, &actualWorkerDS)
+		err := daemonsetAPI.SetWorkerDaemonsetAsDesired(ctx, &nfdCR, &actualWorkerDS, nfdCR.Spec.Operand.Image)
 
 		Expect(err).To(BeNil())
 		expectedYAMLFile, err := os.ReadFile("testdata/test_worker_daemonset.yaml")

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -70,29 +70,29 @@ func (mr *MockDaemonsetAPIMockRecorder) GetDaemonSet(ctx, namespace, name any) *
 }
 
 // SetTopologyDaemonsetAsDesired mocks base method.
-func (m *MockDaemonsetAPI) SetTopologyDaemonsetAsDesired(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, topologyDS *v10.DaemonSet) error {
+func (m *MockDaemonsetAPI) SetTopologyDaemonsetAsDesired(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, topologyDS *v10.DaemonSet, operandImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetTopologyDaemonsetAsDesired", ctx, nfdInstance, topologyDS)
+	ret := m.ctrl.Call(m, "SetTopologyDaemonsetAsDesired", ctx, nfdInstance, topologyDS, operandImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetTopologyDaemonsetAsDesired indicates an expected call of SetTopologyDaemonsetAsDesired.
-func (mr *MockDaemonsetAPIMockRecorder) SetTopologyDaemonsetAsDesired(ctx, nfdInstance, topologyDS any) *gomock.Call {
+func (mr *MockDaemonsetAPIMockRecorder) SetTopologyDaemonsetAsDesired(ctx, nfdInstance, topologyDS, operandImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTopologyDaemonsetAsDesired", reflect.TypeOf((*MockDaemonsetAPI)(nil).SetTopologyDaemonsetAsDesired), ctx, nfdInstance, topologyDS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTopologyDaemonsetAsDesired", reflect.TypeOf((*MockDaemonsetAPI)(nil).SetTopologyDaemonsetAsDesired), ctx, nfdInstance, topologyDS, operandImage)
 }
 
 // SetWorkerDaemonsetAsDesired mocks base method.
-func (m *MockDaemonsetAPI) SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, workerDS *v10.DaemonSet) error {
+func (m *MockDaemonsetAPI) SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, workerDS *v10.DaemonSet, operandImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetWorkerDaemonsetAsDesired", ctx, nfdInstance, workerDS)
+	ret := m.ctrl.Call(m, "SetWorkerDaemonsetAsDesired", ctx, nfdInstance, workerDS, operandImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetWorkerDaemonsetAsDesired indicates an expected call of SetWorkerDaemonsetAsDesired.
-func (mr *MockDaemonsetAPIMockRecorder) SetWorkerDaemonsetAsDesired(ctx, nfdInstance, workerDS any) *gomock.Call {
+func (mr *MockDaemonsetAPIMockRecorder) SetWorkerDaemonsetAsDesired(ctx, nfdInstance, workerDS, operandImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkerDaemonsetAsDesired", reflect.TypeOf((*MockDaemonsetAPI)(nil).SetWorkerDaemonsetAsDesired), ctx, nfdInstance, workerDS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkerDaemonsetAsDesired", reflect.TypeOf((*MockDaemonsetAPI)(nil).SetWorkerDaemonsetAsDesired), ctx, nfdInstance, workerDS, operandImage)
 }

--- a/internal/deployment/deployment_test.go
+++ b/internal/deployment/deployment_test.go
@@ -62,7 +62,7 @@ var _ = Describe("SetMasterDeploymentAsDesired", func() {
 			},
 		}
 
-		err := deploymentAPI.SetMasterDeploymentAsDesired(&nfdCR, &masterDep)
+		err := deploymentAPI.SetMasterDeploymentAsDesired(&nfdCR, &masterDep, nfdCR.Spec.Operand.Image)
 
 		Expect(err).To(BeNil())
 		expectedYAMLFile, err := os.ReadFile("testdata/test_master_deployment.yaml")
@@ -104,7 +104,7 @@ var _ = Describe("SetGCDeploymentAsDesired", func() {
 			},
 		}
 
-		err := deploymentAPI.SetGCDeploymentAsDesired(&nfdCR, &masterDep)
+		err := deploymentAPI.SetGCDeploymentAsDesired(&nfdCR, &masterDep, nfdCR.Spec.Operand.Image)
 
 		Expect(err).To(BeNil())
 		expectedYAMLFile, err := os.ReadFile("testdata/test_gc_deployment.yaml")

--- a/internal/deployment/mock_deployment.go
+++ b/internal/deployment/mock_deployment.go
@@ -70,29 +70,29 @@ func (mr *MockDeploymentAPIMockRecorder) GetDeployment(ctx, namespace, name any)
 }
 
 // SetGCDeploymentAsDesired mocks base method.
-func (m *MockDeploymentAPI) SetGCDeploymentAsDesired(nfdInstance *v1.NodeFeatureDiscovery, gcDep *v10.Deployment) error {
+func (m *MockDeploymentAPI) SetGCDeploymentAsDesired(nfdInstance *v1.NodeFeatureDiscovery, gcDep *v10.Deployment, operandImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetGCDeploymentAsDesired", nfdInstance, gcDep)
+	ret := m.ctrl.Call(m, "SetGCDeploymentAsDesired", nfdInstance, gcDep, operandImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetGCDeploymentAsDesired indicates an expected call of SetGCDeploymentAsDesired.
-func (mr *MockDeploymentAPIMockRecorder) SetGCDeploymentAsDesired(nfdInstance, gcDep any) *gomock.Call {
+func (mr *MockDeploymentAPIMockRecorder) SetGCDeploymentAsDesired(nfdInstance, gcDep, operandImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGCDeploymentAsDesired", reflect.TypeOf((*MockDeploymentAPI)(nil).SetGCDeploymentAsDesired), nfdInstance, gcDep)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGCDeploymentAsDesired", reflect.TypeOf((*MockDeploymentAPI)(nil).SetGCDeploymentAsDesired), nfdInstance, gcDep, operandImage)
 }
 
 // SetMasterDeploymentAsDesired mocks base method.
-func (m *MockDeploymentAPI) SetMasterDeploymentAsDesired(nfdInstance *v1.NodeFeatureDiscovery, masterDep *v10.Deployment) error {
+func (m *MockDeploymentAPI) SetMasterDeploymentAsDesired(nfdInstance *v1.NodeFeatureDiscovery, masterDep *v10.Deployment, operandImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetMasterDeploymentAsDesired", nfdInstance, masterDep)
+	ret := m.ctrl.Call(m, "SetMasterDeploymentAsDesired", nfdInstance, masterDep, operandImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetMasterDeploymentAsDesired indicates an expected call of SetMasterDeploymentAsDesired.
-func (mr *MockDeploymentAPIMockRecorder) SetMasterDeploymentAsDesired(nfdInstance, masterDep any) *gomock.Call {
+func (mr *MockDeploymentAPIMockRecorder) SetMasterDeploymentAsDesired(nfdInstance, masterDep, operandImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMasterDeploymentAsDesired", reflect.TypeOf((*MockDeploymentAPI)(nil).SetMasterDeploymentAsDesired), nfdInstance, masterDep)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetMasterDeploymentAsDesired", reflect.TypeOf((*MockDeploymentAPI)(nil).SetMasterDeploymentAsDesired), nfdInstance, masterDep, operandImage)
 }


### PR DESCRIPTION
Until now, when the Operator image was upgraded, the operand was not upgraded unless the user updated the CR also. Now the operand uses the updated operand-image from the operator itself instead from the CR.

---

/cc @yevgeny-shnaidman @ybettan 