### PR TITLE
Removing image from clusterserviceversion

### DIFF
--- a/config/manifests/bases/nfd.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd.clusterserviceversion.yaml
@@ -16,7 +16,6 @@ metadata:
               "configData": "#    - name: \"more.kernel.features\"\n#      matchOn:\n#      - loadedKMod: [\"example_kmod3\"]\n#    - name: \"more.features.by.nodename\"\n#      value: customValue\n#      matchOn:\n#      - nodename: [\"special-.*-node-.*\"]\n"
             },
             "operand": {
-              "image": "quay.io/openshift/origin-node-feature-discovery:4.18",
               "servicePort": 12000
             },
             "workerConfig": {

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -16,7 +16,6 @@ metadata:
               "configData": "#    - name: \"more.kernel.features\"\n#      matchOn:\n#      - loadedKMod: [\"example_kmod3\"]\n#    - name: \"more.features.by.nodename\"\n#      value: customValue\n#      matchOn:\n#      - nodename: [\"special-.*-node-.*\"]\n"
             },
             "operand": {
-              "image": "quay.io/openshift/origin-node-feature-discovery:4.18",
               "imagePullPolicy": "IfNotPresent",
               "servicePort": 12000
             },


### PR DESCRIPTION
This commit removes the image field from the ClusterServiceVersion resource annotation to ensure that olm-deployed crs do not include it by default.

---

This PR is a follow-up for #396
/cc @yevgeny-shnaidman @ybettan 