### PR TITLE
updating sample NFD CR

### DIFF
--- a/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
@@ -13,7 +13,6 @@ spec:
   ## NOTE: Taints support is experimental.
   #enableTaints: true
   operand:
-    image: quay.io/openshift/origin-node-feature-discovery:4.18
     imagePullPolicy: IfNotPresent
     servicePort: 12000
   workerConfig:


### PR DESCRIPTION
when producing manual bundle, the operator-sdk also looks at config/samples direcotry, and merges it into alm-examples. removing image from CVS in samples produces the correct CVS