### PR TITLE
OCPBUGS-52218: Fix 4.19 CSV references

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-nfd-operator
 
 # Build
@@ -7,9 +7,9 @@ COPY . .
 RUN make build
 
 # Create production image for running the operator
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 
-ARG CSV=4.18
+ARG CSV=4.19
 COPY --from=builder /go/src/github.com/openshift/cluster-nfd-operator/node-feature-discovery-operator /
 
 COPY manifests /manifests

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/openshift/origin-cluster-nfd-operator
-  newTag: "4.18"
+  newTag: "4.19"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -55,7 +55,7 @@ spec:
             - name: OPERATOR_NAME
               value: "cluster-nfd-operator"
             - name: NODE_FEATURE_DISCOVERY_IMAGE
-              value: "quay.io/openshift/origin-node-feature-discovery:4.18"
+              value: "quay.io/openshift/origin-node-feature-discovery:4.19"
           ports:
             - name: metrics
               containerPort: 8080

--- a/config/manifests/bases/nfd.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd.clusterserviceversion.yaml
@@ -64,7 +64,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Integration & Delivery,OpenShift Optional
-    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.18
+    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.19
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.
 
@@ -90,7 +90,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.9.0 <4.18.0'
+    olm.skipRange: '>=4.9.0 <4.19.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-nfd
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -105,7 +105,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: nfd.v4.18.0
+  name: nfd.v4.19.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -806,8 +806,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
-                  value: quay.io/openshift/origin-node-feature-discovery:4.18
-                image: quay.io/openshift/origin-cluster-nfd-operator:4.18
+                  value: quay.io/openshift/origin-node-feature-discovery:4.19
+                image: quay.io/openshift/origin-cluster-nfd-operator:4.19
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -930,7 +930,7 @@ spec:
   - node-labels
   links:
   - name: Node Feature Discovery Operator
-    url: https://docs.openshift.com/container-platform/4.18/hardware_enablement/psap-node-feature-discovery-operator.html
+    url: https://docs.openshift.com/container-platform/4.19/hardware_enablement/psap-node-feature-discovery-operator.html
   - name: Node Feature Discovery Documentation
     url: https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html
   maintainers:
@@ -941,4 +941,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/cluster-nfd-operator
-  version: 4.18.0
+  version: 4.19.0

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,11 +5,11 @@ spec:
   - name: node-feature-discovery
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-node-feature-discovery:4.18
+      name: quay.io/openshift/origin-node-feature-discovery:4.19
   - name: cluster-nfd-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-cluster-nfd-operator:4.18
+      name: quay.io/openshift/origin-cluster-nfd-operator:4.19
   - name: kube-rbac-proxy
     from:
       kind: DockerImage

--- a/manifests/nfd.package.yaml
+++ b/manifests/nfd.package.yaml
@@ -1,5 +1,5 @@
 packageName: nfd
 channels:
 - name: stable
-  currentCSV: nfd.v4.18.0
+  currentCSV: nfd.v4.19.0
 defaultChannel: stable

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -65,7 +65,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Integration & Delivery,OpenShift Optional
-    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.18
+    containerImage: quay.io/openshift/origin-cluster-nfd-operator:4.19
     createdAt: "2024-12-19T11:01:35Z"
     description: |-
       The Node Feature Discovery Operator manages the detection of hardware features and configuration in a Kubernetes cluster by labeling the nodes with hardware-specific information. The Node Feature Discovery (NFD) will label the host with node-specific attributes, like PCI cards, kernel, or OS version, and many more.
@@ -92,7 +92,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    olm.skipRange: '>=4.9.0 <4.18.0'
+    olm.skipRange: '>=4.9.0 <4.19.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-nfd
     operators.openshift.io/infrastructure-features: '["disconnected"]'
@@ -107,7 +107,7 @@ metadata:
     operatorframework.io/arch.arm64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: nfd.v4.18.0
+  name: nfd.v4.19.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -710,8 +710,8 @@ spec:
                 - name: OPERATOR_NAME
                   value: cluster-nfd-operator
                 - name: NODE_FEATURE_DISCOVERY_IMAGE
-                  value: quay.io/openshift/origin-node-feature-discovery:4.18
-                image: quay.io/openshift/origin-cluster-nfd-operator:4.18
+                  value: quay.io/openshift/origin-node-feature-discovery:4.19
+                image: quay.io/openshift/origin-cluster-nfd-operator:4.19
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -833,7 +833,7 @@ spec:
   - node-labels
   links:
   - name: Node Feature Discovery Operator
-    url: https://docs.openshift.com/container-platform/4.18/hardware_enablement/psap-node-feature-discovery-operator.html
+    url: https://docs.openshift.com/container-platform/4.19/hardware_enablement/psap-node-feature-discovery-operator.html
   - name: Node Feature Discovery Documentation
     url: https://kubernetes-sigs.github.io/node-feature-discovery/stable/get-started/index.html
   maintainers:
@@ -844,4 +844,4 @@ spec:
   provider:
     name: Red Hat
     url: https://github.com/openshift/cluster-nfd-operator
-  version: 4.18.0
+  version: 4.19.0


### PR DESCRIPTION
Fix CSV validation by ART; currently failing with:

```
Bundle cluster-nfd-operator-metadata-container-v4.19.0.202503031239.p0.ga3de6d9.assembly.stream.el9-2 CSV metadata.name has no datestamp: nfd.v4.18.0
Bundle cluster-nfd-operator-metadata-container-v4.19.0.202503031239.p0.ga3de6d9.assembly.stream.el9-2 CSV spec.version has no datestamp: 4.18.0
```

Incorporates https://github.com/openshift/cluster-nfd-operator/pull/408
