### PR TITLE
Fixing the DNS policy of the operand

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -66,7 +66,6 @@ func (d *daemonset) SetTopologyDaemonsetAsDesired(ctx context.Context, nfdInstan
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: "nfd-topology-updater",
-				DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 				Containers: []corev1.Container{
 					{
 						Name:            "nfd-topology-updater",
@@ -249,7 +248,6 @@ func (d *daemonset) SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance
 
 				ServiceAccountName: "nfd-worker",
 				HostNetwork:        true,
-				DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 				Containers: []corev1.Container{
 					{
 						Env:             getWorkerEnvs(),

--- a/internal/daemonset/testdata/test_topology_daemonset.yaml
+++ b/internal/daemonset/testdata/test_topology_daemonset.yaml
@@ -21,7 +21,6 @@ spec:
         app: nfd-topology-updater
     spec:
       serviceAccountName: nfd-topology-updater
-      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: nfd-topology-updater
           env:

--- a/internal/daemonset/testdata/test_worker_daemonset.yaml
+++ b/internal/daemonset/testdata/test_worker_daemonset.yaml
@@ -84,7 +84,6 @@ spec:
         - mountPath: /host-usr/src
           name: host-usr-src
           readOnly: true
-      dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: nfd-worker
       tolerations:
       - effect: NoSchedule

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -72,7 +72,6 @@ func (d *deployment) SetMasterDeploymentAsDesired(nfdInstance *nfdv1.NodeFeature
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: "nfd-master",
-				DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 				RestartPolicy:      corev1.RestartPolicyAlways,
 				Tolerations:        getPodsTolerations(),
 				Affinity:           getPodsAffinity(),
@@ -111,7 +110,6 @@ func (d *deployment) SetGCDeploymentAsDesired(nfdInstance *nfdv1.NodeFeatureDisc
 			},
 			Spec: corev1.PodSpec{
 				ServiceAccountName: "nfd-gc",
-				DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 				RestartPolicy:      corev1.RestartPolicyAlways,
 				Containers: []corev1.Container{
 					{

--- a/internal/deployment/testdata/test_gc_deployment.yaml
+++ b/internal/deployment/testdata/test_gc_deployment.yaml
@@ -21,7 +21,6 @@ spec:
         app: nfd-gc
     spec:
       serviceAccountName: nfd-gc
-      dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
       containers:
         - name: nfd-gc

--- a/internal/deployment/testdata/test_master_deployment.yaml
+++ b/internal/deployment/testdata/test_master_deployment.yaml
@@ -21,7 +21,6 @@ spec:
         app: nfd-master
     spec:
       serviceAccountName: nfd-master
-      dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always
       tolerations:
       - effect: NoSchedule
@@ -58,8 +57,7 @@ spec:
           imagePullPolicy: Always
           command:
             - "nfd-master"
-          args:
-            - "--port=12000"
+          args: []
           securityContext:
             runAsNonRoot: true
             seccompProfile:


### PR DESCRIPTION
In OCP the dns policy field not be set, which will make OCP assign it to the Default dns policy