### PR TITLE
Adding tolerations implementation to master and worker pod

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -238,13 +238,8 @@ func (d *daemonset) SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance
 				Labels: getWorkerLabelsAForApp("nfd-worker"),
 			},
 			Spec: corev1.PodSpec{
-				Tolerations: []corev1.Toleration{
-					{
-						Operator: "Exists",
-						Effect:   "NoSchedule",
-					},
-				},
-				Affinity: getWorkerAffinity(),
+				Tolerations: getWorkerTolerations(nfdInstance),
+				Affinity:    getWorkerAffinity(),
 
 				ServiceAccountName: "nfd-worker",
 				HostNetwork:        true,

--- a/internal/daemonset/worker.go
+++ b/internal/daemonset/worker.go
@@ -19,6 +19,7 @@ package daemonset
 import (
 	corev1 "k8s.io/api/core/v1"
 
+	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -198,4 +199,15 @@ func getWorkerVolumes() []corev1.Volume {
 
 func getWorkerLabelsAForApp(name string) map[string]string {
 	return map[string]string{"app": name}
+}
+
+func getWorkerTolerations(nfdInstance *nfdv1.NodeFeatureDiscovery) []corev1.Toleration {
+	basicTolerations := []corev1.Toleration{
+		{
+			Operator: "Exists",
+			Effect:   "NoSchedule",
+		},
+	}
+
+	return append(basicTolerations, nfdInstance.Spec.Operand.WorkerTolerations...)
 }

--- a/internal/daemonset/worker_test.go
+++ b/internal/daemonset/worker_test.go
@@ -1,0 +1,71 @@
+package daemonset
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("getWorkerToleration", func() {
+
+	It("worker tolerations are not defined in NFD CR", func() {
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{},
+			},
+		}
+		expectedTolerations := []corev1.Toleration{
+			{
+				Operator: "Exists",
+				Effect:   "NoSchedule",
+			},
+		}
+
+		res := getWorkerTolerations(&nfdCR)
+		Expect(res).To(Equal(expectedTolerations))
+	})
+
+	It("worker tolerations are defined in NFD CR", func() {
+		workerTolerations := []corev1.Toleration{
+			{
+				Key:      "key1",
+				Value:    "value1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "key1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{
+					WorkerTolerations: workerTolerations,
+				},
+			},
+		}
+		expectedTolerations := []corev1.Toleration{
+			{
+				Operator: "Exists",
+				Effect:   "NoSchedule",
+			},
+			{
+				Key:      "key1",
+				Value:    "value1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "key1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+
+		res := getWorkerTolerations(&nfdCR)
+		Expect(res).To(Equal(expectedTolerations))
+	})
+})

--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -73,7 +73,7 @@ func (d *deployment) SetMasterDeploymentAsDesired(nfdInstance *nfdv1.NodeFeature
 			Spec: corev1.PodSpec{
 				ServiceAccountName: "nfd-master",
 				RestartPolicy:      corev1.RestartPolicyAlways,
-				Tolerations:        getPodsTolerations(),
+				Tolerations:        getPodsTolerations(nfdInstance),
 				Affinity:           getPodsAffinity(),
 				Containers: []corev1.Container{
 					{
@@ -149,8 +149,8 @@ func (d *deployment) GetDeployment(ctx context.Context, namespace, name string) 
 	return dep, err
 }
 
-func getPodsTolerations() []corev1.Toleration {
-	return []corev1.Toleration{
+func getPodsTolerations(nfdInstance *nfdv1.NodeFeatureDiscovery) []corev1.Toleration {
+	basicTolerations := []corev1.Toleration{
 		{
 			Key:      "node-role.kubernetes.io/master",
 			Operator: corev1.TolerationOpEqual,
@@ -162,6 +162,8 @@ func getPodsTolerations() []corev1.Toleration {
 			Effect:   corev1.TaintEffectNoSchedule,
 		},
 	}
+
+	return append(basicTolerations, nfdInstance.Spec.Operand.MasterTolerations...)
 }
 
 func getPodsAffinity() *corev1.Affinity {

--- a/internal/deployment/deployment_test.go
+++ b/internal/deployment/deployment_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/openshift/cluster-nfd-operator/internal/client"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -200,5 +201,79 @@ var _ = Describe("GetDeployment", func() {
 		clnt.EXPECT().Get(ctx, ctrlclient.ObjectKey{Namespace: testNamespace, Name: testName}, gomock.Any()).Return(fmt.Errorf("some error"))
 		_, err := deploymentAPI.GetDeployment(ctx, testNamespace, testName)
 		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("getPodsTolerations", func() {
+	It("no tolerations defined in the NFD CR", func() {
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{},
+			},
+		}
+		expectedTolerations := []corev1.Toleration{
+			{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "node-role.kubernetes.io/control-plane",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+
+		res := getPodsTolerations(&nfdCR)
+		Expect(res).To(Equal(expectedTolerations))
+	})
+
+	It("tolerations defined in the NFD CR", func() {
+		masterTolerations := []corev1.Toleration{
+			{
+				Key:      "key1",
+				Value:    "value1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "key1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{
+					MasterTolerations: masterTolerations,
+				},
+			},
+		}
+		expectedTolerations := []corev1.Toleration{
+			{
+				Key:      "node-role.kubernetes.io/master",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "node-role.kubernetes.io/control-plane",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "key1",
+				Value:    "value1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+			{
+				Key:      "key1",
+				Operator: corev1.TolerationOpEqual,
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		}
+
+		res := getPodsTolerations(&nfdCR)
+		Expect(res).To(Equal(expectedTolerations))
 	})
 })


### PR DESCRIPTION
This commit add tolerations defined in the WorkerTolerations field of the NFD CR to the worker daemonset tolerations definition.It also does the same for master deployment based on the MasterTolerations field of the NFD CR