### PR TITLE
Changing the Probes of the operator pod

### DIFF
--- a/internal/deployment/testdata/test_master_deployment.yaml
+++ b/internal/deployment/testdata/test_master_deployment.yaml
@@ -68,11 +68,21 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
           livenessProbe:
-            grpc:
-              port: 8082
+            httpGet:
+              path: /healthz
+              port: http
             initialDelaySeconds: 10
           readinessProbe:
-            grpc:
-              port: 8082
+            httpGet:
+              path: /healthz
+              port: http
             failureThreshold: 10
             initialDelaySeconds: 5
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            failureThreshold: 30
+          ports:
+          - containerPort: 8080
+            name: http 


### PR DESCRIPTION
1. Changing the liveness and Readiness probes to use the same http pod
2. Adding the StartupProbe to support large clusters configuration
3. Adding port configuration to support all 3 probes