### PR TITLE
Fixing the clusterrolebindings for prune and topology

### DIFF
--- a/config/rbac/gc/clusterrole_binding.yaml
+++ b/config/rbac/gc/clusterrole_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nfd-gc
-  namespace: default
+  namespace: openshift-nfd

--- a/config/rbac/prune/clusterrole_binding.yaml
+++ b/config/rbac/prune/clusterrole_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nfd-prune
-  namespace: node-feature-discovery-operator
+  namespace: openshift-nfd

--- a/config/rbac/topologyupdater/clusterrole_binding.yaml
+++ b/config/rbac/topologyupdater/clusterrole_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nfd-topology-updater
-  namespace: node-feature-discovery
+  namespace: openshift-nfd

--- a/manifests/stable/manifests/nfd-prune_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/manifests/stable/manifests/nfd-prune_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nfd-prune
-  namespace: node-feature-discovery-operator
+  namespace: openshift-nfd

--- a/manifests/stable/manifests/nfd-topology-updater_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
+++ b/manifests/stable/manifests/nfd-topology-updater_rbac.authorization.k8s.io_v1_clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nfd-topology-updater
-  namespace: node-feature-discovery
+  namespace: openshift-nfd


### PR DESCRIPTION
Fixing the clusterrolebindins of prune and topology-updater to point to the appropriate SA in the correct (openshift-nfd) namespaces