### PR TITLE
Fixing official bundle generation

### DIFF
--- a/manifests/stable/manifests/nfd-master_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/manifests/stable/manifests/nfd-master_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -46,3 +46,20 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  - nodefeaturerules
+  - nodefeaturegroups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeaturegroup/status
+  verbs:
+  - patch
+  - update

--- a/manifests/stable/manifests/nfd-worker_rbac.authorization.k8s.io_v1_role.yaml
+++ b/manifests/stable/manifests/nfd-worker_rbac.authorization.k8s.io_v1_role.yaml
@@ -44,3 +44,21 @@ rules:
   - pods
   verbs:
   - get
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
+  - nfd.k8s-sigs.io
+  resources:
+  - nodefeatures/finalizers
+  verbs:
+  - update
+  - get
+  - create
+  - delete


### PR DESCRIPTION
ART bundle is built from the manifests directory. This commit updates the master cluster and worker role in the manifests directory