### PR TITLE
Adding node selector option for the worker pods

### DIFF
--- a/api/v1/nodefeaturediscovery_types.go
+++ b/api/v1/nodefeaturediscovery_types.go
@@ -107,6 +107,9 @@ type OperandSpec struct {
 
 	// MasterEnv defines environment variables to be added to the master deployment
 	MasterEnvs []corev1.EnvVar `json:"masterEnvs,omitempty"`
+	
+	// WorkerNodeSelector describes on which nodes the worker pod should be deployed.
+        WorkerNodeSelector map[string]string `json:"workerNodeSelector,omitempty"`
 }
 
 // ConfigMap describes configuration options for the NFD worker

--- a/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/config/crd/bases/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -352,6 +352,12 @@ spec:
                       - name
                       type: object
                     type: array
+                  workerNodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: WorkerNodeSelector describes on which nodes the worker
+                      pod should be deployed.
+                    type: object
                   workerTolerations:
                     description: WorkerTolerations defines tolerations to be applied
                       to the worker Daemonset

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -262,6 +262,7 @@ func (d *daemonset) SetWorkerDaemonsetAsDesired(ctx context.Context, nfdInstance
 					},
 				},
 				Volumes: getWorkerVolumes(),
+				NodeSelector: nfdInstance.Spec.Operand.WorkerNodeSelector,
 			},
 		},
 	}

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -95,6 +95,7 @@ var _ = Describe("SetWorkerDaemonsetAsDesired", func() {
 			Spec: nfdv1.NodeFeatureDiscoverySpec{
 				Operand: nfdv1.OperandSpec{
 					Image: "test-image",
+					WorkerNodeSelector: map[string]string{"worker-pod": "true"},
 				},
 			},
 		}

--- a/internal/daemonset/testdata/test_worker_daemonset.yaml
+++ b/internal/daemonset/testdata/test_worker_daemonset.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: nfd-worker
     spec:
+      nodeSelector:
+        worker-pod: "true"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/manifests/stable/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
+++ b/manifests/stable/manifests/nfd.openshift.io_nodefeaturediscoveries.yaml
@@ -352,6 +352,12 @@ spec:
                       - name
                       type: object
                     type: array
+                  workerNodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: WorkerNodeSelector describes on which nodes the worker
+                      pod should be deployed.
+                    type: object
                   workerTolerations:
                     description: WorkerTolerations defines tolerations to be applied
                       to the worker Daemonset


### PR DESCRIPTION
This commit adds a field WorkerNodeSelector to the NFD CR that allows user to defined on which worker nodes the NFD worker pods should be scheduled