### PR TITLE
Remove references to "customConfig" field

### DIFF
--- a/config/manifests/bases/nfd.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd.clusterserviceversion.yaml
@@ -12,9 +12,6 @@ metadata:
             "namespace": "openshift-nfd"
           },
           "spec": {
-            "customConfig": {
-              "configData": "#    - name: \"more.kernel.features\"\n#      matchOn:\n#      - loadedKMod: [\"example_kmod3\"]\n#    - name: \"more.features.by.nodename\"\n#      value: customValue\n#      matchOn:\n#      - nodename: [\"special-.*-node-.*\"]\n"
-            },
             "operand": {
               "imagePullPolicy": "IfNotPresent",
               "servicePort": 12000

--- a/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
+++ b/config/samples/nfd.openshift.io_v1_nodefeaturediscovery.yaml
@@ -123,12 +123,3 @@ spec:
       #            vendor: ["15b3"]
       #            device: ["1014", "1017"]
       #          loadedKMod : ["vendor_kmod1", "vendor_kmod2"]
-  customConfig:
-    configData: |
-      #    - name: "more.kernel.features"
-      #      matchOn:
-      #      - loadedKMod: ["example_kmod3"]
-      #    - name: "more.features.by.nodename"
-      #      value: customValue
-      #      matchOn:
-      #      - nodename: ["special-.*-node-.*"]

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -50,9 +50,6 @@ metadata:
             "namespace": "openshift-nfd"
           },
           "spec": {
-            "customConfig": {
-              "configData": "#    - name: \"more.kernel.features\"\n#      matchOn:\n#      - loadedKMod: [\"example_kmod3\"]\n#    - name: \"more.features.by.nodename\"\n#      value: customValue\n#      matchOn:\n#      - nodename: [\"special-.*-node-.*\"]\n"
-            },
             "operand": {
               "imagePullPolicy": "IfNotPresent",
               "servicePort": 12000


### PR DESCRIPTION
Fix for this issue: https://github.com/openshift/cluster-nfd-operator/issues/453

This field has been removed from the CRD but was still included in the sample.