### PR TITLE
OCPBUGS-62306:fixing the prune job's image selection

### DIFF
--- a/internal/controllers/mock_nodefeaturediscovery_reconciler.go
+++ b/internal/controllers/mock_nodefeaturediscovery_reconciler.go
@@ -84,18 +84,18 @@ func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handleMaster(ctx, nfdIn
 }
 
 // handlePrune mocks base method.
-func (m *MocknodeFeatureDiscoveryHelperAPI) handlePrune(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery) (bool, error) {
+func (m *MocknodeFeatureDiscoveryHelperAPI) handlePrune(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, operandImage string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handlePrune", ctx, nfdInstance)
+	ret := m.ctrl.Call(m, "handlePrune", ctx, nfdInstance, operandImage)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // handlePrune indicates an expected call of handlePrune.
-func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handlePrune(ctx, nfdInstance any) *gomock.Call {
+func (mr *MocknodeFeatureDiscoveryHelperAPIMockRecorder) handlePrune(ctx, nfdInstance, operandImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handlePrune", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handlePrune), ctx, nfdInstance)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handlePrune", reflect.TypeOf((*MocknodeFeatureDiscoveryHelperAPI)(nil).handlePrune), ctx, nfdInstance, operandImage)
 }
 
 // handleSCCs mocks base method.

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -36,7 +36,7 @@ import (
 
 type JobAPI interface {
 	GetJob(ctx context.Context, namespace, name string) (*batchv1.Job, error)
-	CreatePruneJob(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery) error
+	CreatePruneJob(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery, operandImage string) error
 }
 
 type job struct {
@@ -61,7 +61,7 @@ func (j *job) GetJob(ctx context.Context, namespace, name string) (*batchv1.Job,
 	return pruneJob, nil
 }
 
-func (j *job) CreatePruneJob(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery) error {
+func (j *job) CreatePruneJob(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery, operandImage string) error {
 	pruneJob := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nfd-prune",
@@ -82,7 +82,7 @@ func (j *job) CreatePruneJob(ctx context.Context, nfdInstance *nfdv1.NodeFeature
 					Containers: []corev1.Container{
 						{
 							Name:            "nfd-prune",
-							Image:           nfdInstance.Spec.Operand.ImagePath(),
+							Image:           operandImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Command: []string{
 								"nfd-master",

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -101,7 +101,7 @@ var _ = Describe("CreatePruneJob", func() {
 
 		clnt.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&testPruneJob))
 
-		err = jobAPI.CreatePruneJob(ctx, &nfdCR)
+		err = jobAPI.CreatePruneJob(ctx, &nfdCR, "test-image")
 		Expect(err).To(BeNil())
 	})
 })

--- a/internal/job/mock_job.go
+++ b/internal/job/mock_job.go
@@ -43,17 +43,17 @@ func (m *MockJobAPI) EXPECT() *MockJobAPIMockRecorder {
 }
 
 // CreatePruneJob mocks base method.
-func (m *MockJobAPI) CreatePruneJob(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery) error {
+func (m *MockJobAPI) CreatePruneJob(ctx context.Context, nfdInstance *v1.NodeFeatureDiscovery, operandImage string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePruneJob", ctx, nfdInstance)
+	ret := m.ctrl.Call(m, "CreatePruneJob", ctx, nfdInstance, operandImage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreatePruneJob indicates an expected call of CreatePruneJob.
-func (mr *MockJobAPIMockRecorder) CreatePruneJob(ctx, nfdInstance any) *gomock.Call {
+func (mr *MockJobAPIMockRecorder) CreatePruneJob(ctx, nfdInstance, operandImage any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePruneJob", reflect.TypeOf((*MockJobAPI)(nil).CreatePruneJob), ctx, nfdInstance)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePruneJob", reflect.TypeOf((*MockJobAPI)(nil).CreatePruneJob), ctx, nfdInstance, operandImage)
 }
 
 // GetJob mocks base method.


### PR DESCRIPTION
since we have moved using the operand image defined in the ENV variable of the operator, the operand image is extrapolated at the begining of the reconcile cycle. and should be passed to prune job also.