### PR TITLE
Fixing metrics configuration

### DIFF
--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -3,7 +3,7 @@ kind: ControllerManagerConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: 127.0.0.1:8080
+  bindAddress: :8443
 webhook:
   port: 9443
 leaderElection:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
           command:
             - /node-feature-discovery-operator
           args:
-            - "--metrics-bind-address=127.0.0.1:8080"
+            - "--metrics-bind-address=:8443"
             - "--leader-elect"
           image: controller:latest
           env:
@@ -57,8 +57,12 @@ spec:
             - name: NODE_FEATURE_DISCOVERY_IMAGE
               value: "quay.io/openshift/origin-node-feature-discovery:4.20"
           ports:
-            - name: metrics
-              containerPort: 8080
+            - name: https
+              containerPort: 8443
+          volumeMounts:
+            - name: metrics-certs
+              mountPath: /etc/metrics-certs
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -71,4 +75,8 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+      volumes:
+        - name: metrics-certs
+          secret:
+            secretName: node-feature-discovery-operator-tls
       terminationGracePeriodSeconds: 10

--- a/config/manifests/bases/nfd.clusterserviceversion.yaml
+++ b/config/manifests/bases/nfd.clusterserviceversion.yaml
@@ -684,7 +684,7 @@ spec:
             spec:
               containers:
               - args:
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=:8443
                 - --leader-elect
                 command:
                 - /node-feature-discovery-operator
@@ -712,8 +712,8 @@ spec:
                   periodSeconds: 20
                 name: manager
                 ports:
-                - containerPort: 8080
-                  name: metrics
+                - containerPort: 8443
+                  name: https
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -730,8 +730,16 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                volumeMounts:
+                - mountPath: /etc/metrics-certs
+                  name: metrics-certs
+                  readOnly: true
               serviceAccountName: nfd-manager
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: metrics-certs
+                secret:
+                  secretName: node-feature-discovery-operator-tls
       permissions:
       - rules:
         - apiGroups:

--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func main() {
 		BindAddress:    args.metricsAddr,
 		SecureServing:  true,
 		FilterProvider: filters.WithAuthenticationAndAuthorization,
+		CertDir:        "/etc/metrics-certs",
 	}
 
 	// Create a new manager to manage the operator
@@ -198,7 +199,7 @@ func initFlags(flagset *flag.FlagSet) *operatorArgs {
 	args := operatorArgs{}
 
 	// Setup CLI arguments
-	flagset.StringVar(&args.metricsAddr, "metrics-bind-address", ":8080", "The address the Prometheus "+
+	flagset.StringVar(&args.metricsAddr, "metrics-bind-address", ":8443", "The address the Prometheus "+
 		"metric endpoint binds to for scraping NFD resource usage data.")
 	flagset.StringVar(&args.probeAddr, "health-probe-bind-address", ":8081", "The address the probe "+
 		"endpoint binds to for determining liveness, readiness, and configuration of"+

--- a/manifests/stable/manifests/nfd-manager-config_v1_configmap.yaml
+++ b/manifests/stable/manifests/nfd-manager-config_v1_configmap.yaml
@@ -6,7 +6,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: :8443
     webhook:
       port: 9443
     leaderElection:

--- a/manifests/stable/manifests/nfd.clusterserviceversion.yaml
+++ b/manifests/stable/manifests/nfd.clusterserviceversion.yaml
@@ -717,7 +717,7 @@ spec:
             spec:
               containers:
               - args:
-                - --metrics-bind-address=127.0.0.1:8080
+                - --metrics-bind-address=:8443
                 - --leader-elect
                 command:
                 - /node-feature-discovery-operator
@@ -745,8 +745,8 @@ spec:
                   periodSeconds: 20
                 name: manager
                 ports:
-                - containerPort: 8080
-                  name: metrics
+                - containerPort: 8443
+                  name: https
                 readinessProbe:
                   httpGet:
                     path: /readyz
@@ -763,8 +763,16 @@ spec:
                   runAsNonRoot: true
                   seccompProfile:
                     type: RuntimeDefault
+                volumeMounts:
+                - mountPath: /etc/metrics-certs
+                  name: metrics-certs
+                  readOnly: true
               serviceAccountName: nfd-manager
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: metrics-certs
+                secret:
+                  secretName: node-feature-discovery-operator-tls
       permissions:
       - rules:
         - apiGroups:


### PR DESCRIPTION
1. Changing controller listening to 8443 and not to inner 8080 - since kube-rbac-proxy is no longer in the play
2. Adjusting port targeting to https instead of metrics -  the same as defined by the service
3. Mounting tls