### PR TITLE
Fixing GC ImagePullPolicy

### DIFF
--- a/internal/deployment/deployment.go
+++ b/internal/deployment/deployment.go
@@ -123,7 +123,7 @@ func (d *deployment) SetGCDeploymentAsDesired(nfdInstance *nfdv1.NodeFeatureDisc
 					{
 						Name:            "nfd-gc",
 						Image:           operandImage,
-						ImagePullPolicy: corev1.PullAlways,
+						ImagePullPolicy: getImagePullPolicy(nfdInstance),
 						Command: []string{
 							"nfd-gc",
 						},


### PR DESCRIPTION
ImagePullPolicy for GC deployment  should honor the NodeFeatureDiscovery CR configuration