### PR TITLE
Add egress restrictions to NFD NetworkPolicies

### DIFF
--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -58,8 +58,9 @@ func (n *networkPolicy) SetMasterNetworkPolicyAsDesired(nfdInstance *nfdv1.NodeF
 	}
 	np.Spec = networkingv1.NetworkPolicySpec{
 		PodSelector: podSelector,
-		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		Ingress:     healthProbeIngressRules(),
+		Egress:      requiredEgressRules(),
 	}
 	return controllerutil.SetControllerReference(nfdInstance, np, n.scheme)
 }
@@ -70,8 +71,9 @@ func (n *networkPolicy) SetWorkerNetworkPolicyAsDesired(nfdInstance *nfdv1.NodeF
 	}
 	np.Spec = networkingv1.NetworkPolicySpec{
 		PodSelector: podSelector,
-		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+		Egress:      requiredEgressRules(),
 	}
 	return controllerutil.SetControllerReference(nfdInstance, np, n.scheme)
 }
@@ -82,8 +84,9 @@ func (n *networkPolicy) SetGCNetworkPolicyAsDesired(nfdInstance *nfdv1.NodeFeatu
 	}
 	np.Spec = networkingv1.NetworkPolicySpec{
 		PodSelector: podSelector,
-		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress},
+		PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
 		Ingress:     healthProbeIngressRules(),
+		Egress:      requiredEgressRules(),
 	}
 	return controllerutil.SetControllerReference(nfdInstance, np, n.scheme)
 }
@@ -112,6 +115,39 @@ func healthProbeIngressRules() []networkingv1.NetworkPolicyIngressRule {
 					Protocol: &tcp,
 					Port:     &httpPort,
 				},
+			},
+		},
+	}
+}
+
+// requiredEgressRules returns the minimal egress ports needed by every NFD
+// component: DNS resolution and kube-apiserver communication. Rules are
+// port-only (no destination/peer restriction) because both the apiserver and
+// CoreDNS on OpenShift are host-networked pods, whose matching behaviour in
+// namespace/pod selectors is implementation-defined and unreliable for egress
+// targeting on OVN-Kubernetes. Port-only rules are the pattern used by
+// upstream node-feature-discovery's Helm chart.
+func requiredEgressRules() []networkingv1.NetworkPolicyEgressRule {
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+	httpsPort := intstr.FromInt32(443)
+	apiServerPort := intstr.FromInt32(6443)
+	dnsPort := intstr.FromInt32(53)
+	// OVN-Kubernetes evaluates egress rules after Service DNAT, so the
+	// destination port is the pod's targetPort (5353), not the Service
+	// port (53). Both are needed: 53 for compatibility with other CNIs,
+	// 5353 for OVN-Kubernetes on OpenShift.
+	dnsTargetPort := intstr.FromInt32(5353)
+
+	return []networkingv1.NetworkPolicyEgressRule{
+		{
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &tcp, Port: &httpsPort},
+				{Protocol: &tcp, Port: &apiServerPort},
+				{Protocol: &tcp, Port: &dnsPort},
+				{Protocol: &udp, Port: &dnsPort},
+				{Protocol: &tcp, Port: &dnsTargetPort},
+				{Protocol: &udp, Port: &dnsTargetPort},
 			},
 		},
 	}

--- a/internal/networkpolicy/networkpolicy_test.go
+++ b/internal/networkpolicy/networkpolicy_test.go
@@ -53,7 +53,7 @@ var _ = Describe("SetMasterNetworkPolicyAsDesired", func() {
 		Expect(err).To(BeNil())
 
 		Expect(np.Spec.PodSelector.MatchLabels).To(Equal(map[string]string{"app": "nfd-master"}))
-		Expect(np.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress}))
+		Expect(np.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}))
 		Expect(np.Spec.Ingress).To(HaveLen(1))
 
 		httpPort := intstr.FromInt32(8080)
@@ -61,6 +61,8 @@ var _ = Describe("SetMasterNetworkPolicyAsDesired", func() {
 		Expect(np.Spec.Ingress[0].Ports).To(Equal([]networkingv1.NetworkPolicyPort{
 			{Protocol: &tcp, Port: &httpPort},
 		}))
+
+		assertRequiredEgressRules(np.Spec.Egress)
 	})
 })
 
@@ -84,8 +86,10 @@ var _ = Describe("SetWorkerNetworkPolicyAsDesired", func() {
 		Expect(err).To(BeNil())
 
 		Expect(np.Spec.PodSelector.MatchLabels).To(Equal(map[string]string{"app": "nfd-worker"}))
-		Expect(np.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress}))
+		Expect(np.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}))
 		Expect(np.Spec.Ingress).To(BeEmpty())
+
+		assertRequiredEgressRules(np.Spec.Egress)
 	})
 })
 
@@ -109,7 +113,7 @@ var _ = Describe("SetGCNetworkPolicyAsDesired", func() {
 		Expect(err).To(BeNil())
 
 		Expect(np.Spec.PodSelector.MatchLabels).To(Equal(map[string]string{"app": "nfd-gc"}))
-		Expect(np.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress}))
+		Expect(np.Spec.PolicyTypes).To(Equal([]networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress}))
 		Expect(np.Spec.Ingress).To(HaveLen(1))
 
 		httpPort := intstr.FromInt32(8080)
@@ -117,6 +121,8 @@ var _ = Describe("SetGCNetworkPolicyAsDesired", func() {
 		Expect(np.Spec.Ingress[0].Ports).To(Equal([]networkingv1.NetworkPolicyPort{
 			{Protocol: &tcp, Port: &httpPort},
 		}))
+
+		assertRequiredEgressRules(np.Spec.Egress)
 	})
 })
 
@@ -164,3 +170,23 @@ var _ = Describe("DeleteNetworkPolicy", func() {
 		Expect(err).To(BeNil())
 	})
 })
+
+func assertRequiredEgressRules(egress []networkingv1.NetworkPolicyEgressRule) {
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+	httpsPort := intstr.FromInt32(443)
+	apiServerPort := intstr.FromInt32(6443)
+	dnsPort := intstr.FromInt32(53)
+	dnsTargetPort := intstr.FromInt32(5353)
+
+	Expect(egress).To(HaveLen(1))
+	Expect(egress[0].To).To(BeNil())
+	Expect(egress[0].Ports).To(Equal([]networkingv1.NetworkPolicyPort{
+		{Protocol: &tcp, Port: &httpsPort},
+		{Protocol: &tcp, Port: &apiServerPort},
+		{Protocol: &tcp, Port: &dnsPort},
+		{Protocol: &udp, Port: &dnsPort},
+		{Protocol: &tcp, Port: &dnsTargetPort},
+		{Protocol: &udp, Port: &dnsTargetPort},
+	}))
+}


### PR DESCRIPTION
The existing NetworkPolicies for nfd-master, nfd-worker, and nfd-gc only declared Ingress in policyTypes, leaving egress completely unrestricted (default-allow). This adds Egress to policyTypes and limits outbound traffic to only the ports NFD needs:

- 443/tcp  — kube-apiserver (HTTPS)
- 6443/tcp — kube-apiserver (OpenShift)
- 53/tcp+udp  — DNS (Service port)
- 5353/tcp+udp — DNS (targetPort, required because OVN-Kubernetes evaluates egress rules after Service DNAT)

Rules are port-only (no To/peer selectors) because the apiserver and CoreDNS are host-networked on OpenShift, making namespace/pod selectors unreliable under OVN-Kubernetes. This matches the upstream NFD Helm chart pattern.

Note: nfd-worker runs with hostNetwork: true, so NetworkPolicy is not enforced on it by the kernel — the policy is applied as a declaration of intent.

---

/cc @yevgeny-shnaidman 