### PR TITLE
Surface OperandImagePinned condition and warning event

### DIFF
--- a/internal/controllers/nodefeaturediscovery_reconciler.go
+++ b/internal/controllers/nodefeaturediscovery_reconciler.go
@@ -28,8 +28,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,8 +60,8 @@ type nodeFeatureDiscoveryReconciler struct {
 
 func NewNodeFeatureDiscoveryReconciler(client client.Client, deploymentAPI deployment.DeploymentAPI, daemonsetAPI daemonset.DaemonsetAPI,
 	configmapAPI configmap.ConfigMapAPI, jobAPI job.JobAPI, sccAPI scc.SccAPI, networkPolicyAPI networkpolicy.NetworkPolicyAPI,
-	statusAPI status.StatusAPI, scheme *runtime.Scheme) *nodeFeatureDiscoveryReconciler {
-	helper := newNodeFeatureDiscoveryHelperAPI(client, deploymentAPI, daemonsetAPI, configmapAPI, jobAPI, sccAPI, networkPolicyAPI, statusAPI, scheme)
+	statusAPI status.StatusAPI, scheme *runtime.Scheme, recorder record.EventRecorder) *nodeFeatureDiscoveryReconciler {
+	helper := newNodeFeatureDiscoveryHelperAPI(client, deploymentAPI, daemonsetAPI, configmapAPI, jobAPI, sccAPI, networkPolicyAPI, statusAPI, scheme, recorder)
 	return &nodeFeatureDiscoveryReconciler{
 		helper: helper,
 	}
@@ -114,6 +116,7 @@ func getOperandImage(nfdInstance *nfdv1.NodeFeatureDiscovery) string {
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=nfd.k8s-sigs.io,resources=nodefeaturerules,verbs=get;list;watch
@@ -215,11 +218,12 @@ type nodeFeatureDiscoveryHelper struct {
 	networkPolicyAPI networkpolicy.NetworkPolicyAPI
 	statusAPI        status.StatusAPI
 	scheme           *runtime.Scheme
+	recorder         record.EventRecorder
 }
 
 func newNodeFeatureDiscoveryHelperAPI(client client.Client, deploymentAPI deployment.DeploymentAPI, daemonsetAPI daemonset.DaemonsetAPI,
 	configmapAPI configmap.ConfigMapAPI, jobAPI job.JobAPI, sccAPI scc.SccAPI, networkPolicyAPI networkpolicy.NetworkPolicyAPI,
-	statusAPI status.StatusAPI, scheme *runtime.Scheme) nodeFeatureDiscoveryHelperAPI {
+	statusAPI status.StatusAPI, scheme *runtime.Scheme, recorder record.EventRecorder) nodeFeatureDiscoveryHelperAPI {
 	return &nodeFeatureDiscoveryHelper{
 		client:           client,
 		deploymentAPI:    deploymentAPI,
@@ -230,6 +234,7 @@ func newNodeFeatureDiscoveryHelperAPI(client client.Client, deploymentAPI deploy
 		networkPolicyAPI: networkPolicyAPI,
 		statusAPI:        statusAPI,
 		scheme:           scheme,
+		recorder:         recorder,
 	}
 }
 
@@ -476,7 +481,31 @@ func (nfdh *nodeFeatureDiscoveryHelper) handleStatus(ctx context.Context, nfdIns
 	if nfdh.statusAPI.AreConditionsEqual(nfdInstance.Status.Conditions, conditions) {
 		return nil
 	}
+	oldConditions := nfdInstance.Status.Conditions
 	unmodifiedCR := nfdInstance.DeepCopy()
 	nfdInstance.Status.Conditions = conditions
-	return nfdh.client.Status().Patch(ctx, nfdInstance, client.MergeFrom(unmodifiedCR))
+	if err := nfdh.client.Status().Patch(ctx, nfdInstance, client.MergeFrom(unmodifiedCR)); err != nil {
+		return err
+	}
+	// Only emit the event once the new conditions have actually persisted, so a failed/retried
+	// patch can't cause the event to fire without a corresponding status update (or fire twice).
+	nfdh.recordOperandImagePinnedEvent(nfdInstance, oldConditions, conditions)
+	return nil
+}
+
+// recordOperandImagePinnedEvent emits a Warning event the first time spec.operand.image becomes
+// pinned, so it shows up in `oc get events -n <namespace>` without needing to inspect
+// status.conditions directly. It only fires on the False->True transition (not every reconcile).
+func (nfdh *nodeFeatureDiscoveryHelper) recordOperandImagePinnedEvent(nfdInstance *nfdv1.NodeFeatureDiscovery, oldConditions, newConditions []metav1.Condition) {
+	if nfdh.recorder == nil {
+		return
+	}
+	newCond := meta.FindStatusCondition(newConditions, status.ConditionOperandImagePinned)
+	if newCond == nil || newCond.Status != metav1.ConditionTrue {
+		return
+	}
+	if oldCond := meta.FindStatusCondition(oldConditions, status.ConditionOperandImagePinned); oldCond != nil && oldCond.Status == metav1.ConditionTrue {
+		return
+	}
+	nfdh.recorder.Event(nfdInstance, corev1.EventTypeWarning, newCond.Reason, newCond.Message)
 }

--- a/internal/controllers/nodefeaturediscovery_reconciler_test.go
+++ b/internal/controllers/nodefeaturediscovery_reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -191,7 +192,7 @@ var _ = Describe("handleMaster", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockDeployment = deployment.NewMockDeploymentAPI(ctrl)
 
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, mockDeployment, nil, nil, nil, nil, nil, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, mockDeployment, nil, nil, nil, nil, nil, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -260,7 +261,7 @@ var _ = Describe("handleWorker", func() {
 		mockDS = daemonset.NewMockDaemonsetAPI(ctrl)
 		mockCM = configmap.NewMockConfigMapAPI(ctrl)
 
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, mockDS, mockCM, nil, nil, nil, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, mockDS, mockCM, nil, nil, nil, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -356,7 +357,7 @@ var _ = Describe("handleTopology", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockDS = daemonset.NewMockDaemonsetAPI(ctrl)
 
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, mockDS, nil, nil, nil, nil, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, mockDS, nil, nil, nil, nil, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -441,7 +442,7 @@ var _ = Describe("handleGC", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockDeployment = deployment.NewMockDeploymentAPI(ctrl)
 
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, mockDeployment, nil, nil, nil, nil, nil, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, mockDeployment, nil, nil, nil, nil, nil, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -508,7 +509,7 @@ var _ = Describe("handleNetworkPolicies", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockNP = networkpolicy.NewMockNetworkPolicyAPI(ctrl)
 
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, mockNP, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, mockNP, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -576,7 +577,7 @@ var _ = Describe("handleNetworkPolicies", func() {
 
 var _ = Describe("hasFinalizer", func() {
 	It("checking return status whether finalizer set or not", func() {
-		nfdh := newNodeFeatureDiscoveryHelperAPI(nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		nfdh := newNodeFeatureDiscoveryHelperAPI(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		By("finalizers was empty")
 		nfdCR := nfdv1.NodeFeatureDiscovery{
@@ -620,7 +621,7 @@ var _ = Describe("setFinalizer", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, nil, nil, nil)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	It("checking the return status of setFinalizer function", func() {
@@ -683,7 +684,7 @@ var _ = Describe("finalizeComponents", func() {
 		mockSCC = scc.NewMockSccAPI(ctrl)
 		mockNP = networkpolicy.NewMockNetworkPolicyAPI(ctrl)
 
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, mockDeployment, mockDS, mockCM, nil, mockSCC, mockNP, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, mockDeployment, mockDS, mockCM, nil, mockSCC, mockNP, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -782,7 +783,7 @@ var _ = Describe("removeFinalizer", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, nil, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, nil, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -826,7 +827,7 @@ var _ = Describe("handlePrune", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockJob = job.NewMockJobAPI(ctrl)
-		nfdh = newNodeFeatureDiscoveryHelperAPI(nil, nil, nil, nil, mockJob, nil, nil, nil, scheme)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(nil, nil, nil, nil, mockJob, nil, nil, nil, scheme, nil)
 	})
 
 	ctx := context.Background()
@@ -913,6 +914,7 @@ var _ = Describe("handleStatus", func() {
 		ctrl       *gomock.Controller
 		clnt       *client.MockClient
 		mockStatus *status.MockStatusAPI
+		recorder   *record.FakeRecorder
 		nfdh       nodeFeatureDiscoveryHelperAPI
 	)
 
@@ -920,7 +922,8 @@ var _ = Describe("handleStatus", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		mockStatus = status.NewMockStatusAPI(ctrl)
-		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, nil, mockStatus, scheme)
+		recorder = record.NewFakeRecorder(10)
+		nfdh = newNodeFeatureDiscoveryHelperAPI(clnt, nil, nil, nil, nil, nil, nil, mockStatus, scheme, recorder)
 	})
 
 	ctx := context.Background()
@@ -934,7 +937,7 @@ var _ = Describe("handleStatus", func() {
 	It("conditions are equal, no status update is needed", func() {
 		gomock.InOrder(
 			mockStatus.EXPECT().GetConditions(ctx, &nfdCR).Return(newConditions),
-			mockStatus.EXPECT().AreConditionsEqual(newConditions, nfdCR.Status.Conditions).Return(true),
+			mockStatus.EXPECT().AreConditionsEqual(nfdCR.Status.Conditions, newConditions).Return(true),
 		)
 
 		err := nfdh.handleStatus(ctx, &nfdCR)
@@ -950,7 +953,7 @@ var _ = Describe("handleStatus", func() {
 		}
 		gomock.InOrder(
 			mockStatus.EXPECT().GetConditions(ctx, &nfdCR).Return(newConditions),
-			mockStatus.EXPECT().AreConditionsEqual(newConditions, nfdCR.Status.Conditions).Return(false),
+			mockStatus.EXPECT().AreConditionsEqual(nfdCR.Status.Conditions, newConditions).Return(false),
 			clnt.EXPECT().Status().Return(statusWriter),
 			statusWriter.EXPECT().Patch(ctx, &expectedNFD, gomock.Any()).Return(nil),
 		)
@@ -968,13 +971,157 @@ var _ = Describe("handleStatus", func() {
 		}
 		gomock.InOrder(
 			mockStatus.EXPECT().GetConditions(ctx, &nfdCR).Return(newConditions),
-			mockStatus.EXPECT().AreConditionsEqual(newConditions, nfdCR.Status.Conditions).Return(false),
+			mockStatus.EXPECT().AreConditionsEqual(nfdCR.Status.Conditions, newConditions).Return(false),
 			clnt.EXPECT().Status().Return(statusWriter),
 			statusWriter.EXPECT().Patch(ctx, &expectedNFD, gomock.Any()).Return(fmt.Errorf("some error")),
 		)
 
 		err := nfdh.handleStatus(ctx, &nfdCR)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("emits a Warning event when OperandImagePinned newly becomes True, only after the status patch succeeds", func() {
+		pinnedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{Conditions: []metav1.Condition{}},
+		}
+		newConds := []metav1.Condition{
+			{Type: status.ConditionOperandImagePinned, Status: metav1.ConditionTrue, Reason: "OperandImageSetExplicitly", Message: "pinned to some-image"},
+		}
+		expectedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{Conditions: newConds},
+		}
+		statusWriter := client.NewMockStatusWriter(ctrl)
+		gomock.InOrder(
+			mockStatus.EXPECT().GetConditions(ctx, &pinnedNFD).Return(newConds),
+			mockStatus.EXPECT().AreConditionsEqual(pinnedNFD.Status.Conditions, newConds).Return(false),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Patch(ctx, &expectedNFD, gomock.Any()).Return(nil),
+		)
+
+		err := nfdh.handleStatus(ctx, &pinnedNFD)
+		Expect(err).To(BeNil())
+
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("pinned to some-image")))
+	})
+
+	It("does not emit the event if the status patch fails", func() {
+		pinnedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{Conditions: []metav1.Condition{}},
+		}
+		newConds := []metav1.Condition{
+			{Type: status.ConditionOperandImagePinned, Status: metav1.ConditionTrue, Reason: "OperandImageSetExplicitly", Message: "pinned to some-image"},
+		}
+		expectedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{Conditions: newConds},
+		}
+		statusWriter := client.NewMockStatusWriter(ctrl)
+		gomock.InOrder(
+			mockStatus.EXPECT().GetConditions(ctx, &pinnedNFD).Return(newConds),
+			mockStatus.EXPECT().AreConditionsEqual(pinnedNFD.Status.Conditions, newConds).Return(false),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Patch(ctx, &expectedNFD, gomock.Any()).Return(fmt.Errorf("some error")),
+		)
+
+		err := nfdh.handleStatus(ctx, &pinnedNFD)
+		Expect(err).To(HaveOccurred())
+
+		Consistently(recorder.Events).ShouldNot(Receive())
+	})
+
+	It("does not re-emit the event once OperandImagePinned is already True", func() {
+		alreadyPinnedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{
+				Conditions: []metav1.Condition{
+					{Type: status.ConditionOperandImagePinned, Status: metav1.ConditionTrue, Reason: "OperandImageSetExplicitly", Message: "pinned to some-image"},
+				},
+			},
+		}
+		newConds := alreadyPinnedNFD.Status.Conditions
+		mockStatus.EXPECT().GetConditions(ctx, &alreadyPinnedNFD).Return(newConds)
+		mockStatus.EXPECT().AreConditionsEqual(alreadyPinnedNFD.Status.Conditions, newConds).Return(true)
+
+		err := nfdh.handleStatus(ctx, &alreadyPinnedNFD)
+		Expect(err).To(BeNil())
+
+		Consistently(recorder.Events).ShouldNot(Receive())
+	})
+
+	It("does not re-emit the event when conditions change for an unrelated reason but OperandImagePinned was already True", func() {
+		pinnedCond := metav1.Condition{Type: status.ConditionOperandImagePinned, Status: metav1.ConditionTrue, Reason: "OperandImageSetExplicitly", Message: "pinned to some-image"}
+		alreadyPinnedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{
+				Conditions: []metav1.Condition{pinnedCond},
+			},
+		}
+		newConds := []metav1.Condition{
+			{Type: "Available", Status: metav1.ConditionFalse, Reason: "SomeFailure"},
+			pinnedCond,
+		}
+		expectedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{Conditions: newConds},
+		}
+		statusWriter := client.NewMockStatusWriter(ctrl)
+		gomock.InOrder(
+			mockStatus.EXPECT().GetConditions(ctx, &alreadyPinnedNFD).Return(newConds),
+			mockStatus.EXPECT().AreConditionsEqual(alreadyPinnedNFD.Status.Conditions, newConds).Return(false),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Patch(ctx, &expectedNFD, gomock.Any()).Return(nil),
+		)
+
+		err := nfdh.handleStatus(ctx, &alreadyPinnedNFD)
+		Expect(err).To(BeNil())
+
+		Consistently(recorder.Events).ShouldNot(Receive())
+	})
+
+	It("does not emit an event when OperandImagePinned transitions from True to False (image un-pinned)", func() {
+		previouslyPinnedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{
+				Conditions: []metav1.Condition{
+					{Type: status.ConditionOperandImagePinned, Status: metav1.ConditionTrue, Reason: "OperandImageSetExplicitly", Message: "pinned to old-image"},
+				},
+			},
+		}
+		newConds := []metav1.Condition{
+			{Type: status.ConditionOperandImagePinned, Status: metav1.ConditionFalse, Reason: "OperandImageManagedByOperator"},
+		}
+		expectedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{Conditions: newConds},
+		}
+		statusWriter := client.NewMockStatusWriter(ctrl)
+		gomock.InOrder(
+			mockStatus.EXPECT().GetConditions(ctx, &previouslyPinnedNFD).Return(newConds),
+			mockStatus.EXPECT().AreConditionsEqual(previouslyPinnedNFD.Status.Conditions, newConds).Return(false),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Patch(ctx, &expectedNFD, gomock.Any()).Return(nil),
+		)
+
+		err := nfdh.handleStatus(ctx, &previouslyPinnedNFD)
+		Expect(err).To(BeNil())
+
+		Consistently(recorder.Events).ShouldNot(Receive())
+	})
+
+	It("emits a Warning event when OperandImagePinned newly becomes True, even from a nil (never-set) Status.Conditions", func() {
+		pinnedNFD := nfdv1.NodeFeatureDiscovery{}
+		newConds := []metav1.Condition{
+			{Type: status.ConditionOperandImagePinned, Status: metav1.ConditionTrue, Reason: "OperandImageSetExplicitly", Message: "pinned to some-image"},
+		}
+		expectedNFD := nfdv1.NodeFeatureDiscovery{
+			Status: nfdv1.NodeFeatureDiscoveryStatus{Conditions: newConds},
+		}
+		statusWriter := client.NewMockStatusWriter(ctrl)
+		gomock.InOrder(
+			mockStatus.EXPECT().GetConditions(ctx, &pinnedNFD).Return(newConds),
+			mockStatus.EXPECT().AreConditionsEqual(pinnedNFD.Status.Conditions, newConds).Return(false),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Patch(ctx, &expectedNFD, gomock.Any()).Return(nil),
+		)
+
+		err := nfdh.handleStatus(ctx, &pinnedNFD)
+		Expect(err).To(BeNil())
+
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("pinned to some-image")))
 	})
 })
 

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -18,6 +18,7 @@ package status
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -70,6 +71,16 @@ const (
 	// message field should contain a human readable description of what the administrator should do to
 	// allow the operator to successfully update the resources maintained by the operator.
 	conditionUpgradeable string = "Upgradeable"
+
+	// ConditionOperandImagePinned indicates whether spec.operand.image is explicitly set on the CR.
+	// It is reported independently of Available/Degraded/Progressing/Upgradeable so that it stays
+	// visible even when the operator is otherwise degraded (e.g. because the pinned image is stale).
+	// Exported so callers (e.g. the reconciler, when deciding whether to emit an Event) can look this
+	// condition up without duplicating the string literal.
+	ConditionOperandImagePinned string = "OperandImagePinned"
+
+	reasonOperandImagePinned    = "OperandImageSetExplicitly"
+	reasonOperandImageNotPinned = "OperandImageManagedByOperator"
 )
 
 //go:generate mockgen -source=status.go -package=status -destination=mock_status.go StatusAPI
@@ -91,6 +102,14 @@ func NewStatusAPI(deploymentAPI deployment.DeploymentAPI, daemonsetAPI daemonset
 }
 
 func (s *status) GetConditions(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery) []metav1.Condition {
+	conditions := s.getComponentConditions(ctx, nfdInstance)
+	// OperandImagePinned is computed independently of the other conditions above (rather than folded
+	// into e.g. Upgradeable) so that it stays visible even when the CR is already Degraded/Progressing
+	// for an unrelated reason - which is exactly the case we most want to catch.
+	return append(conditions, getOperandImagePinnedCondition(nfdInstance))
+}
+
+func (s *status) getComponentConditions(ctx context.Context, nfdInstance *nfdv1.NodeFeatureDiscovery) []metav1.Condition {
 	// get worker daemonset conditions
 	nonAvailableConditions := s.helper.getWorkerNotAvailableConditions(ctx, nfdInstance)
 	if nonAvailableConditions != nil {
@@ -115,6 +134,35 @@ func (s *status) GetConditions(ctx context.Context, nfdInstance *nfdv1.NodeFeatu
 	}
 
 	return getAvailableConditions()
+}
+
+// getOperandImagePinnedCondition reports whether spec.operand.image is explicitly set. Setting it
+// pins the operand to that image forever: unlike the default (empty) case, the operand will not be
+// updated when the operator itself is upgraded, which can leave the cluster running a stale/incompatible
+// operand (see OCPBUGS-85506).
+func getOperandImagePinnedCondition(nfdInstance *nfdv1.NodeFeatureDiscovery) metav1.Condition {
+	image := nfdInstance.Spec.Operand.Image
+	now := metav1.Time{Time: time.Now()}
+	if image == "" {
+		return metav1.Condition{
+			Type:               ConditionOperandImagePinned,
+			Status:             metav1.ConditionFalse,
+			Reason:             reasonOperandImageNotPinned,
+			LastTransitionTime: now,
+		}
+	}
+	return metav1.Condition{
+		Type:   ConditionOperandImagePinned,
+		Status: metav1.ConditionTrue,
+		Reason: reasonOperandImagePinned,
+		Message: fmt.Sprintf(
+			"spec.operand.image is pinned to %q and will not be updated when the operator is upgraded, "+
+				"which can leave the operand stale or incompatible (e.g. port conflicts). "+
+				"Clear this field to let the operator manage the operand image automatically.",
+			image,
+		),
+		LastTransitionTime: now,
+	}
 }
 
 func (s *status) AreConditionsEqual(prevConditions, newConditions []metav1.Condition) bool {

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
+	meta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	nfdv1 "github.com/openshift/cluster-nfd-operator/api/v1"
@@ -86,7 +87,7 @@ var _ = Describe("GetConditions", func() {
 
 	executeTestFunction:
 		conds := st.GetConditions(ctx, &nfdCR)
-		compareConditions(conds, expectConds)
+		compareConditions(conds, append(append([]metav1.Condition{}, expectConds...), getOperandImagePinnedCondition(&nfdCR)))
 	},
 		Entry("worker is not available yet", false, false, false, false),
 		Entry("worker available, master is not yet", true, false, false, false),
@@ -94,6 +95,80 @@ var _ = Describe("GetConditions", func() {
 		Entry("worker,master and gc available, topology is not yet", true, true, true, false),
 		Entry("all components are available", true, true, true, true),
 	)
+})
+
+var _ = Describe("GetConditions - OperandImagePinned", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockHelper *MockstatusHelperAPI
+		st         *status
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockHelper = NewMockstatusHelperAPI(ctrl)
+		st = &status{
+			helper: mockHelper,
+		}
+	})
+
+	ctx := context.Background()
+
+	expectAllComponentsAvailable := func() {
+		mockHelper.EXPECT().getWorkerNotAvailableConditions(ctx, gomock.Any()).Return(nil)
+		mockHelper.EXPECT().getMasterNotAvailableConditions(ctx, gomock.Any()).Return(nil)
+		mockHelper.EXPECT().getGCNotAvailableConditions(ctx, gomock.Any()).Return(nil)
+	}
+
+	It("reports OperandImagePinned=False when spec.operand.image is empty and everything is healthy", func() {
+		nfdCR := nfdv1.NodeFeatureDiscovery{}
+		expectAllComponentsAvailable()
+
+		conds := st.GetConditions(ctx, &nfdCR)
+
+		cond := meta.FindStatusCondition(conds, ConditionOperandImagePinned)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(reasonOperandImageNotPinned))
+	})
+
+	It("reports OperandImagePinned=True with the image in the message when spec.operand.image is set and everything is healthy", func() {
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{Image: "registry.k8s.io/nfd/node-feature-discovery:v0.15.5"},
+			},
+		}
+		expectAllComponentsAvailable()
+
+		conds := st.GetConditions(ctx, &nfdCR)
+
+		cond := meta.FindStatusCondition(conds, ConditionOperandImagePinned)
+		Expect(cond).ToNot(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		Expect(cond.Reason).To(Equal(reasonOperandImagePinned))
+		Expect(cond.Message).To(ContainSubstring("registry.k8s.io/nfd/node-feature-discovery:v0.15.5"))
+	})
+
+	It("still reports OperandImagePinned=True even when the CR is otherwise Degraded", func() {
+		nfdCR := nfdv1.NodeFeatureDiscovery{
+			Spec: nfdv1.NodeFeatureDiscoverySpec{
+				Operand: nfdv1.OperandSpec{Image: "registry.k8s.io/nfd/node-feature-discovery:v0.15.5"},
+			},
+		}
+		mockHelper.EXPECT().getWorkerNotAvailableConditions(ctx, gomock.Any()).
+			Return(getDegradedConditions("NFDWorkerDaemonSetDegraded", "0 nodes have pods scheduled"))
+
+		conds := st.GetConditions(ctx, &nfdCR)
+
+		degraded := meta.FindStatusCondition(conds, conditionDegraded)
+		Expect(degraded).ToNot(BeNil())
+		Expect(degraded.Status).To(Equal(metav1.ConditionTrue))
+
+		pinned := meta.FindStatusCondition(conds, ConditionOperandImagePinned)
+		Expect(pinned).ToNot(BeNil())
+		Expect(pinned.Status).To(Equal(metav1.ConditionTrue))
+		Expect(pinned.Reason).To(Equal(reasonOperandImagePinned))
+	})
 })
 
 var _ = Describe("AreConditionsEqual", func() {

--- a/main.go
+++ b/main.go
@@ -157,6 +157,8 @@ func main() {
 	networkPolicyAPI := networkpolicy.NewNetworkPolicyAPI(client, scheme)
 	statusAPI := status.NewStatusAPI(deploymentAPI, daemonsetAPI)
 
+	recorder := mgr.GetEventRecorderFor("nodefeaturediscovery-controller")
+
 	if err = new_controllers.NewNodeFeatureDiscoveryReconciler(client,
 		deploymentAPI,
 		daemonsetAPI,
@@ -165,7 +167,8 @@ func main() {
 		sccAPI,
 		networkPolicyAPI,
 		statusAPI,
-		scheme).SetupWithManager(mgr); err != nil {
+		scheme,
+		recorder).SetupWithManager(mgr); err != nil {
 		setupLogger.Error(err, "unable to create controller", "controller", "NodeFeatureDiscovery")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Pinning spec.operand.image on the NodeFeatureDiscovery CR silently opts the operand out of automatic image updates on operator upgrades, which can leave it stale or incompatible, There was previously no visibility into this state.

Add an OperandImagePinned status condition, computed independently of Available/Degraded/Progressing/Upgradeable so it stays visible even when the operator is otherwise degraded, and emit a Warning event via the manager's EventRecorder the first time it transitions to True so it shows up in `oc get events` and must-gather without needing to inspect status.conditions directly.

---

/cc @chr15p 
/assign @chr15p 